### PR TITLE
feat(smartcomments): support @simpleCollections smart comment

### DIFF
--- a/__tests__/integration/schema/__snapshots__/manyToMany.simpleCollectionsBoth.test.js.snap
+++ b/__tests__/integration/schema/__snapshots__/manyToMany.simpleCollectionsBoth.test.js.snap
@@ -153,23 +153,6 @@ type Person implements Node {
     \\"\\"\\"The method to use when ordering \`Team\`.\\"\\"\\"
     orderBy: [TeamsOrderBy!] = [PRIMARY_KEY_ASC]
   ): TeamsConnection!
-
-  \\"\\"\\"Reads and enables pagination through a set of \`Team\`.\\"\\"\\"
-  teamsByTeamMemberPersonIdAndTeamIdList(
-    \\"\\"\\"
-    A condition to be used in determining which values should be returned by the collection.
-    \\"\\"\\"
-    condition: TeamCondition
-
-    \\"\\"\\"Only read the first \`n\` values of the set.\\"\\"\\"
-    first: Int
-
-    \\"\\"\\"Skip the first \`n\` values.\\"\\"\\"
-    offset: Int
-
-    \\"\\"\\"The method to use when ordering \`Team\`.\\"\\"\\"
-    orderBy: [TeamsOrderBy!]
-  ): [Team!]!
 }
 
 \\"\\"\\"

--- a/__tests__/p-schema.sql
+++ b/__tests__/p-schema.sql
@@ -21,3 +21,4 @@ create table p.team_member (
 
 comment on constraint team_member_person_id_fkey on p.team_member is E'@manyToManyFieldName members\n@manyToManySimpleFieldName membersList';
 
+comment on constraint team_member_team_id_fkey on p.team_member is E'@simpleCollections omit';

--- a/src/PgManyToManyRelationPlugin.js
+++ b/src/PgManyToManyRelationPlugin.js
@@ -2,10 +2,6 @@ module.exports = function PgManyToManyRelationPlugin(
   builder,
   { pgSimpleCollections }
 ) {
-  const hasConnections = pgSimpleCollections !== "only";
-  const hasSimpleCollections =
-    pgSimpleCollections === "only" || pgSimpleCollections === "both";
-
   builder.hook("inflection", inflection => {
     return Object.assign(inflection, {
       manyToManyRelationByKeys(
@@ -338,6 +334,13 @@ module.exports = function PgManyToManyRelationPlugin(
               )} and ${describePgEntity(junctionRightConstraint)}.`
             );
           }
+          const simpleCollections =
+            junctionRightConstraint.tags.simpleCollections ||
+            rightTable.tags.simpleCollections ||
+            pgSimpleCollections;
+          const hasConnections = simpleCollections !== "only";
+          const hasSimpleCollections =
+            simpleCollections === "only" || simpleCollections === "both";
           if (hasConnections) {
             makeFields(true);
           }


### PR DESCRIPTION
This adds support for the `@simpleCollections` smart comment on tables/constraints.

Logic taken from: https://github.com/graphile/graphile-engine/blob/c3dd9cf061a1d1498e189a69f1a35befe4bc83f5/packages/graphile-build-pg/src/plugins/PgBackwardRelationPlugin.js#L453-L459

Relevant docs: https://www.graphile.org/postgraphile/smart-comments/#simple-collections