### PR TITLE
chore: pass context to queryFromResolveData

### DIFF
--- a/src/PgManyToManyRelationPlugin.js
+++ b/src/PgManyToManyRelationPlugin.js
@@ -291,7 +291,8 @@ module.exports = function PgManyToManyRelationPlugin(
                                   )})`
                                 );
                               },
-                              queryBuilder.context
+                              queryBuilder.context,
+                              queryBuilder.rootValue
                             );
                             return sql.fragment`(${query})`;
                           }, getSafeAliasFromAlias(parsedResolveInfoFragment.alias));

--- a/src/PgManyToManyRelationPlugin.js
+++ b/src/PgManyToManyRelationPlugin.js
@@ -290,7 +290,8 @@ module.exports = function PgManyToManyRelationPlugin(
                                     leftKeyAttribute.name
                                   )})`
                                 );
-                              }
+                              },
+                              queryBuilder.context
                             );
                             return sql.fragment`(${query})`;
                           }, getSafeAliasFromAlias(parsedResolveInfoFragment.alias));


### PR DESCRIPTION
This is causing context to be an empty object for nested data requests. Also as comment says, context won't be [optional anymore in v5](https://github.com/graphile/graphile-engine/blob/d723558b769777c4a9e572d502f1f54844207138/packages/graphile-build-pg/src/queryFromResolveDataFactory.js#L31).