### PR TITLE
smart comment: @manyToManyObjectTypeBaseName

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,11 +132,8 @@ module.exports = makeAddInflectorsPlugin(
       _junctionTable,
       rightTable,
       _junctionLeftConstraint,
-      junctionRightConstraint
+      _junctionRightConstraint
     ) {
-      if (junctionRightConstraint.tags.manyToManyFieldName) {
-        return junctionRightConstraint.tags.manyToManyFieldName;
-      }
       return this.camelCase(
         `${this.pluralize(this._singularizedTableName(rightTable))}`
       );
@@ -149,11 +146,8 @@ module.exports = makeAddInflectorsPlugin(
       _junctionTable,
       rightTable,
       _junctionLeftConstraint,
-      junctionRightConstraint
+      _junctionRightConstraint
     ) {
-      if (junctionRightConstraint.tags.manyToManySimpleFieldName) {
-        return junctionRightConstraint.tags.manyToManySimpleFieldName;
-      }
       return this.camelCase(
         `${this.pluralize(this._singularizedTableName(rightTable))}-list`
       );

--- a/__tests__/__snapshots__/queries.test.js.snap
+++ b/__tests__/__snapshots__/queries.test.js.snap
@@ -649,6 +649,89 @@ Object {
 }
 `;
 
+exports[`schema=e query=multiple-tags-fields.graphql 1`] = `
+Object {
+  "data": Object {
+    "allPeople": Object {
+      "nodes": Array [
+        Object {
+          "personName": "Alice",
+          "tags": Object {
+            "nodes": Array [
+              Object {
+                "tagName": "awesome",
+              },
+            ],
+          },
+          "teams": Object {
+            "nodes": Array [
+              Object {
+                "tags": Object {
+                  "nodes": Array [
+                    Object {
+                      "tagName": "strange",
+                    },
+                  ],
+                },
+                "teamName": "Development",
+              },
+            ],
+          },
+        },
+        Object {
+          "personName": "Bob",
+          "tags": Object {
+            "nodes": Array [
+              Object {
+                "tagName": "strange",
+              },
+            ],
+          },
+          "teams": Object {
+            "nodes": Array [
+              Object {
+                "tags": Object {
+                  "nodes": Array [
+                    Object {
+                      "tagName": "high-performing",
+                    },
+                  ],
+                },
+                "teamName": "Sales",
+              },
+            ],
+          },
+        },
+        Object {
+          "personName": "Carol",
+          "tags": Object {
+            "nodes": Array [
+              Object {
+                "tagName": "high-performing",
+              },
+            ],
+          },
+          "teams": Object {
+            "nodes": Array [
+              Object {
+                "tags": Object {
+                  "nodes": Array [
+                    Object {
+                      "tagName": "awesome",
+                    },
+                  ],
+                },
+                "teamName": "Marketing",
+              },
+            ],
+          },
+        },
+      ],
+    },
+  },
+}
+`;
+
 exports[`schema=f query=f.graphql 1`] = `
 Object {
   "data": Object {

--- a/__tests__/integration/schema/__snapshots__/e.test.js.snap
+++ b/__tests__/integration/schema/__snapshots__/e.test.js.snap
@@ -1,0 +1,1158 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`prints a schema using the 'e' database schema 1`] = `
+"""A location in a connection that can be used for resuming pagination."""
+scalar Cursor
+
+type Membership implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+
+  """Reads a single \`Person\` that is related to this \`Membership\`."""
+  personByPersonId: Person
+  personId: Int!
+
+  """Reads a single \`Team\` that is related to this \`Membership\`."""
+  teamByTeamId: Team
+  teamId: Int!
+}
+
+"""
+A condition to be used against \`Membership\` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+"""
+input MembershipCondition {
+  """Checks for equality with the object’s \`personId\` field."""
+  personId: Int
+
+  """Checks for equality with the object’s \`teamId\` field."""
+  teamId: Int
+}
+
+"""A connection to a list of \`Membership\` values."""
+type MembershipsConnection {
+  """
+  A list of edges which contains the \`Membership\` and cursor to aid in pagination.
+  """
+  edges: [MembershipsEdge!]!
+
+  """A list of \`Membership\` objects."""
+  nodes: [Membership!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`Membership\` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A \`Membership\` edge in the connection."""
+type MembershipsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`Membership\` at the end of the edge."""
+  node: Membership!
+}
+
+"""Methods to use when ordering \`Membership\`."""
+enum MembershipsOrderBy {
+  NATURAL
+  PERSON_ID_ASC
+  PERSON_ID_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  TEAM_ID_ASC
+  TEAM_ID_DESC
+}
+
+"""An object with a globally unique \`ID\`."""
+interface Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+}
+
+"""Information about pagination in a connection."""
+type PageInfo {
+  """When paginating forwards, the cursor to continue."""
+  endCursor: Cursor
+
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: Cursor
+}
+
+"""A connection to a list of \`Person\` values."""
+type PeopleConnection {
+  """
+  A list of edges which contains the \`Person\` and cursor to aid in pagination.
+  """
+  edges: [PeopleEdge!]!
+
+  """A list of \`Person\` objects."""
+  nodes: [Person!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`Person\` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A \`Person\` edge in the connection."""
+type PeopleEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`Person\` at the end of the edge."""
+  node: Person!
+}
+
+"""Methods to use when ordering \`Person\`."""
+enum PeopleOrderBy {
+  ID_ASC
+  ID_DESC
+  NATURAL
+  PERSON_NAME_ASC
+  PERSON_NAME_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+type Person implements Node {
+  id: Int!
+
+  """Reads and enables pagination through a set of \`Membership\`."""
+  membershipsByPersonId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: MembershipCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Membership\`."""
+    orderBy: [MembershipsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): MembershipsConnection!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  personName: String!
+
+  """Reads and enables pagination through a set of \`PersonTagJunction\`."""
+  personTagJunctionsByPersonId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonTagJunctionCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`PersonTagJunction\`."""
+    orderBy: [PersonTagJunctionsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PersonTagJunctionsConnection!
+
+  """Reads and enables pagination through a set of \`Tag\`."""
+  tags(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: TagCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Tag\`."""
+    orderBy: [TagsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PersonTagConnection!
+
+  """Reads and enables pagination through a set of \`Team\`."""
+  teams(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: TeamCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Team\`."""
+    orderBy: [TeamsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PersonTeamConnection!
+}
+
+"""
+A condition to be used against \`Person\` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input PersonCondition {
+  """Checks for equality with the object’s \`id\` field."""
+  id: Int
+
+  """Checks for equality with the object’s \`personName\` field."""
+  personName: String
+}
+
+"""
+A connection to a list of \`Tag\` values, with data from \`PersonTagJunction\`.
+"""
+type PersonTagConnection {
+  """
+  A list of edges which contains the \`Tag\`, info from the \`PersonTagJunction\`, and the cursor to aid in pagination.
+  """
+  edges: [PersonTagEdge!]!
+
+  """A list of \`Tag\` objects."""
+  nodes: [Tag!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`Tag\` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A \`Tag\` edge in the connection, with data from \`PersonTagJunction\`."""
+type PersonTagEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`Tag\` at the end of the edge."""
+  node: Tag!
+}
+
+type PersonTagJunction implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+
+  """Reads a single \`Person\` that is related to this \`PersonTagJunction\`."""
+  personByPersonId: Person
+  personId: Int!
+
+  """Reads a single \`Tag\` that is related to this \`PersonTagJunction\`."""
+  tagByTagId: Tag
+  tagId: Int!
+}
+
+"""
+A condition to be used against \`PersonTagJunction\` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input PersonTagJunctionCondition {
+  """Checks for equality with the object’s \`personId\` field."""
+  personId: Int
+
+  """Checks for equality with the object’s \`tagId\` field."""
+  tagId: Int
+}
+
+"""A connection to a list of \`PersonTagJunction\` values."""
+type PersonTagJunctionsConnection {
+  """
+  A list of edges which contains the \`PersonTagJunction\` and cursor to aid in pagination.
+  """
+  edges: [PersonTagJunctionsEdge!]!
+
+  """A list of \`PersonTagJunction\` objects."""
+  nodes: [PersonTagJunction!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* \`PersonTagJunction\` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+"""A \`PersonTagJunction\` edge in the connection."""
+type PersonTagJunctionsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`PersonTagJunction\` at the end of the edge."""
+  node: PersonTagJunction!
+}
+
+"""Methods to use when ordering \`PersonTagJunction\`."""
+enum PersonTagJunctionsOrderBy {
+  NATURAL
+  PERSON_ID_ASC
+  PERSON_ID_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  TAG_ID_ASC
+  TAG_ID_DESC
+}
+
+"""A connection to a list of \`Team\` values, with data from \`Membership\`."""
+type PersonTeamConnection {
+  """
+  A list of edges which contains the \`Team\`, info from the \`Membership\`, and the cursor to aid in pagination.
+  """
+  edges: [PersonTeamEdge!]!
+
+  """A list of \`Team\` objects."""
+  nodes: [Team!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`Team\` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A \`Team\` edge in the connection, with data from \`Membership\`."""
+type PersonTeamEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`Team\` at the end of the edge."""
+  node: Team!
+}
+
+"""The root query type which gives access points into the data universe."""
+type Query implements Node {
+  """Reads and enables pagination through a set of \`Membership\`."""
+  allMemberships(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: MembershipCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Membership\`."""
+    orderBy: [MembershipsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): MembershipsConnection
+
+  """Reads and enables pagination through a set of \`Person\`."""
+  allPeople(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Person\`."""
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PeopleConnection
+
+  """Reads and enables pagination through a set of \`PersonTagJunction\`."""
+  allPersonTagJunctions(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonTagJunctionCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`PersonTagJunction\`."""
+    orderBy: [PersonTagJunctionsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PersonTagJunctionsConnection
+
+  """Reads and enables pagination through a set of \`Tag\`."""
+  allTags(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: TagCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Tag\`."""
+    orderBy: [TagsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): TagsConnection
+
+  """Reads and enables pagination through a set of \`TeamTagJunction\`."""
+  allTeamTagJunctions(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: TeamTagJunctionCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`TeamTagJunction\`."""
+    orderBy: [TeamTagJunctionsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): TeamTagJunctionsConnection
+
+  """Reads and enables pagination through a set of \`Team\`."""
+  allTeams(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: TeamCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Team\`."""
+    orderBy: [TeamsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): TeamsConnection
+
+  """Reads a single \`Membership\` using its globally unique \`ID\`."""
+  membership(
+    """
+    The globally unique \`ID\` to be used in selecting a single \`Membership\`.
+    """
+    nodeId: ID!
+  ): Membership
+  membershipByPersonIdAndTeamId(personId: Int!, teamId: Int!): Membership
+
+  """Fetches an object given its globally unique \`ID\`."""
+  node(
+    """The globally unique \`ID\`."""
+    nodeId: ID!
+  ): Node
+
+  """
+  The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
+  """
+  nodeId: ID!
+
+  """Reads a single \`Person\` using its globally unique \`ID\`."""
+  person(
+    """The globally unique \`ID\` to be used in selecting a single \`Person\`."""
+    nodeId: ID!
+  ): Person
+  personById(id: Int!): Person
+
+  """Reads a single \`PersonTagJunction\` using its globally unique \`ID\`."""
+  personTagJunction(
+    """
+    The globally unique \`ID\` to be used in selecting a single \`PersonTagJunction\`.
+    """
+    nodeId: ID!
+  ): PersonTagJunction
+  personTagJunctionByPersonIdAndTagId(personId: Int!, tagId: Int!): PersonTagJunction
+
+  """
+  Exposes the root query type nested one level down. This is helpful for Relay 1
+  which can only query top level fields if they are in a particular form.
+  """
+  query: Query!
+
+  """Reads a single \`Tag\` using its globally unique \`ID\`."""
+  tag(
+    """The globally unique \`ID\` to be used in selecting a single \`Tag\`."""
+    nodeId: ID!
+  ): Tag
+  tagById(id: Int!): Tag
+
+  """Reads a single \`Team\` using its globally unique \`ID\`."""
+  team(
+    """The globally unique \`ID\` to be used in selecting a single \`Team\`."""
+    nodeId: ID!
+  ): Team
+  teamById(id: Int!): Team
+
+  """Reads a single \`TeamTagJunction\` using its globally unique \`ID\`."""
+  teamTagJunction(
+    """
+    The globally unique \`ID\` to be used in selecting a single \`TeamTagJunction\`.
+    """
+    nodeId: ID!
+  ): TeamTagJunction
+  teamTagJunctionByTeamIdAndTagId(tagId: Int!, teamId: Int!): TeamTagJunction
+}
+
+type Tag implements Node {
+  id: Int!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+
+  """Reads and enables pagination through a set of \`Person\`."""
+  people(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Person\`."""
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+  ): TagPersonConnection!
+
+  """Reads and enables pagination through a set of \`PersonTagJunction\`."""
+  personTagJunctionsByTagId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonTagJunctionCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`PersonTagJunction\`."""
+    orderBy: [PersonTagJunctionsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PersonTagJunctionsConnection!
+  tagName: String!
+
+  """Reads and enables pagination through a set of \`TeamTagJunction\`."""
+  teamTagJunctionsByTagId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: TeamTagJunctionCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`TeamTagJunction\`."""
+    orderBy: [TeamTagJunctionsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): TeamTagJunctionsConnection!
+
+  """Reads and enables pagination through a set of \`Team\`."""
+  teams(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: TeamCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Team\`."""
+    orderBy: [TeamsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): TagTeamConnection!
+}
+
+"""
+A condition to be used against \`Tag\` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input TagCondition {
+  """Checks for equality with the object’s \`id\` field."""
+  id: Int
+
+  """Checks for equality with the object’s \`tagName\` field."""
+  tagName: String
+}
+
+"""
+A connection to a list of \`Person\` values, with data from \`PersonTagJunction\`.
+"""
+type TagPersonConnection {
+  """
+  A list of edges which contains the \`Person\`, info from the \`PersonTagJunction\`, and the cursor to aid in pagination.
+  """
+  edges: [TagPersonEdge!]!
+
+  """A list of \`Person\` objects."""
+  nodes: [Person!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`Person\` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""
+A \`Person\` edge in the connection, with data from \`PersonTagJunction\`.
+"""
+type TagPersonEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`Person\` at the end of the edge."""
+  node: Person!
+}
+
+"""A connection to a list of \`Tag\` values."""
+type TagsConnection {
+  """
+  A list of edges which contains the \`Tag\` and cursor to aid in pagination.
+  """
+  edges: [TagsEdge!]!
+
+  """A list of \`Tag\` objects."""
+  nodes: [Tag!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`Tag\` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A \`Tag\` edge in the connection."""
+type TagsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`Tag\` at the end of the edge."""
+  node: Tag!
+}
+
+"""Methods to use when ordering \`Tag\`."""
+enum TagsOrderBy {
+  ID_ASC
+  ID_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  TAG_NAME_ASC
+  TAG_NAME_DESC
+}
+
+"""
+A connection to a list of \`Team\` values, with data from \`TeamTagJunction\`.
+"""
+type TagTeamConnection {
+  """
+  A list of edges which contains the \`Team\`, info from the \`TeamTagJunction\`, and the cursor to aid in pagination.
+  """
+  edges: [TagTeamEdge!]!
+
+  """A list of \`Team\` objects."""
+  nodes: [Team!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`Team\` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A \`Team\` edge in the connection, with data from \`TeamTagJunction\`."""
+type TagTeamEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`Team\` at the end of the edge."""
+  node: Team!
+}
+
+type Team implements Node {
+  id: Int!
+
+  """Reads and enables pagination through a set of \`Membership\`."""
+  membershipsByTeamId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: MembershipCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Membership\`."""
+    orderBy: [MembershipsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): MembershipsConnection!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+
+  """Reads and enables pagination through a set of \`Person\`."""
+  people(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Person\`."""
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+  ): TeamPersonConnection!
+
+  """Reads and enables pagination through a set of \`Tag\`."""
+  tags(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: TagCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Tag\`."""
+    orderBy: [TagsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): TeamTagConnection!
+  teamName: String!
+
+  """Reads and enables pagination through a set of \`TeamTagJunction\`."""
+  teamTagJunctionsByTeamId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: TeamTagJunctionCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`TeamTagJunction\`."""
+    orderBy: [TeamTagJunctionsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): TeamTagJunctionsConnection!
+}
+
+"""
+A condition to be used against \`Team\` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input TeamCondition {
+  """Checks for equality with the object’s \`id\` field."""
+  id: Int
+
+  """Checks for equality with the object’s \`teamName\` field."""
+  teamName: String
+}
+
+"""
+A connection to a list of \`Person\` values, with data from \`Membership\`.
+"""
+type TeamPersonConnection {
+  """
+  A list of edges which contains the \`Person\`, info from the \`Membership\`, and the cursor to aid in pagination.
+  """
+  edges: [TeamPersonEdge!]!
+
+  """A list of \`Person\` objects."""
+  nodes: [Person!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`Person\` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A \`Person\` edge in the connection, with data from \`Membership\`."""
+type TeamPersonEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`Person\` at the end of the edge."""
+  node: Person!
+}
+
+"""A connection to a list of \`Team\` values."""
+type TeamsConnection {
+  """
+  A list of edges which contains the \`Team\` and cursor to aid in pagination.
+  """
+  edges: [TeamsEdge!]!
+
+  """A list of \`Team\` objects."""
+  nodes: [Team!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`Team\` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A \`Team\` edge in the connection."""
+type TeamsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`Team\` at the end of the edge."""
+  node: Team!
+}
+
+"""Methods to use when ordering \`Team\`."""
+enum TeamsOrderBy {
+  ID_ASC
+  ID_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  TEAM_NAME_ASC
+  TEAM_NAME_DESC
+}
+
+"""
+A connection to a list of \`Tag\` values, with data from \`TeamTagJunction\`.
+"""
+type TeamTagConnection {
+  """
+  A list of edges which contains the \`Tag\`, info from the \`TeamTagJunction\`, and the cursor to aid in pagination.
+  """
+  edges: [TeamTagEdge!]!
+
+  """A list of \`Tag\` objects."""
+  nodes: [Tag!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`Tag\` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A \`Tag\` edge in the connection, with data from \`TeamTagJunction\`."""
+type TeamTagEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`Tag\` at the end of the edge."""
+  node: Tag!
+}
+
+type TeamTagJunction implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+
+  """Reads a single \`Tag\` that is related to this \`TeamTagJunction\`."""
+  tagByTagId: Tag
+  tagId: Int!
+
+  """Reads a single \`Team\` that is related to this \`TeamTagJunction\`."""
+  teamByTeamId: Team
+  teamId: Int!
+}
+
+"""
+A condition to be used against \`TeamTagJunction\` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+"""
+input TeamTagJunctionCondition {
+  """Checks for equality with the object’s \`tagId\` field."""
+  tagId: Int
+
+  """Checks for equality with the object’s \`teamId\` field."""
+  teamId: Int
+}
+
+"""A connection to a list of \`TeamTagJunction\` values."""
+type TeamTagJunctionsConnection {
+  """
+  A list of edges which contains the \`TeamTagJunction\` and cursor to aid in pagination.
+  """
+  edges: [TeamTagJunctionsEdge!]!
+
+  """A list of \`TeamTagJunction\` objects."""
+  nodes: [TeamTagJunction!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """
+  The count of *all* \`TeamTagJunction\` you could get from the connection.
+  """
+  totalCount: Int!
+}
+
+"""A \`TeamTagJunction\` edge in the connection."""
+type TeamTagJunctionsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`TeamTagJunction\` at the end of the edge."""
+  node: TeamTagJunction!
+}
+
+"""Methods to use when ordering \`TeamTagJunction\`."""
+enum TeamTagJunctionsOrderBy {
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  TAG_ID_ASC
+  TAG_ID_DESC
+  TEAM_ID_ASC
+  TEAM_ID_DESC
+}
+
+`;

--- a/__tests__/integration/schema/e.test.js
+++ b/__tests__/integration/schema/e.test.js
@@ -1,0 +1,10 @@
+const core = require("./core");
+
+test(
+  "prints a schema using the 'e' database schema",
+  core.test(["e"], {
+    appendPlugins: [require("../../../index.js")],
+    disableDefaultMutations: true,
+    setofFunctionsContainNulls: false,
+  })
+);

--- a/__tests__/schemas/e/data.sql
+++ b/__tests__/schemas/e/data.sql
@@ -1,0 +1,29 @@
+insert into e.person (id, person_name) values
+  (1, 'Alice'),
+  (2, 'Bob'),
+  (3, 'Carol');
+
+insert into e.team (id, team_name) values
+  (1, 'Development'),
+  (2, 'Sales'),
+  (3, 'Marketing');
+
+insert into e.tag (id, tag_name) values
+  (1, 'high-performing'),
+  (2, 'awesome'),
+  (3, 'strange');
+
+insert into e.membership (person_id, team_id) values
+  (1, 1),
+  (2, 2),
+  (3, 3);
+
+insert into e.person_tag_junction (person_id, tag_id) values
+  (1, 2),
+  (2, 3),
+  (3, 1);
+
+insert into e.team_tag_junction (team_id, tag_id) values
+  (1, 3),
+  (2, 1),
+  (3, 2);

--- a/__tests__/schemas/e/fixtures/queries/multiple-tags-fields.graphql
+++ b/__tests__/schemas/e/fixtures/queries/multiple-tags-fields.graphql
@@ -1,0 +1,22 @@
+query {
+  allPeople {
+    nodes {
+      personName
+      tags {
+        nodes {
+          tagName
+        }
+      }
+      teams {
+        nodes {
+          teamName
+          tags {
+            nodes {
+              tagName
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/__tests__/schemas/e/schema.sql
+++ b/__tests__/schemas/e/schema.sql
@@ -1,0 +1,51 @@
+-- Scenario:
+-- * multiple junction tables, reusing names
+
+drop schema if exists e cascade;
+
+create schema e;
+
+create table e.person (
+  id serial primary key,
+  person_name text not null
+);
+
+create table e.team (
+  id serial primary key,
+  team_name text not null
+);
+
+create table e.tag (
+  id serial primary key,
+  tag_name text not null
+);
+
+create table e.membership (
+  person_id int not null constraint membership_person_id_fkey references e.person (id),
+  team_id int not null constraint membership_team_id_fkey references e.team (id),
+  primary key (person_id, team_id)
+);
+comment on constraint membership_person_id_fkey on e.membership is
+  E'@manyToManyFieldName people\n@manyToManySimpleFieldName peopleList\n@manyToManyObjectTypeBaseName TeamPerson';
+comment on constraint membership_team_id_fkey on e.membership is
+  E'@manyToManyFieldName teams\n@manyToManySimpleFieldName teamsList\n@manyToManyObjectTypeBaseName PersonTeam';
+
+create table e.person_tag_junction (
+  person_id int not null constraint person_tag_junction_person_id_fkey references e.person (id),
+  tag_id int not null constraint person_tag_junction_tag_id_fkey references e.tag (id),
+  primary key (person_id, tag_id)
+);
+comment on constraint person_tag_junction_person_id_fkey on e.person_tag_junction is
+  E'@manyToManyFieldName people\n@manyToManySimpleFieldName peopleList\n@manyToManyObjectTypeBaseName TagPerson';
+comment on constraint person_tag_junction_tag_id_fkey on e.person_tag_junction is
+  E'@manyToManyFieldName tags\n@manyToManySimpleFieldName tagsList\n@manyToManyObjectTypeBaseName PersonTag';
+
+create table e.team_tag_junction (
+  team_id int not null constraint team_tag_junction_team_id_fkey references e.team (id),
+  tag_id int not null constraint team_tag_junction_tag_id_fkey references e.tag (id),
+  primary key (team_id, tag_id)
+);
+comment on constraint team_tag_junction_team_id_fkey on e.team_tag_junction is
+  E'@manyToManyFieldName teams\n@manyToManySimpleFieldName teamsList\n@manyToManyObjectTypeBaseName TagTeam';
+comment on constraint team_tag_junction_tag_id_fkey on e.team_tag_junction is
+  E'@manyToManyFieldName tags\n@manyToManySimpleFieldName tagsList\n@manyToManyObjectTypeBaseName TeamTag';

--- a/src/PgManyToManyRelationPlugin.js
+++ b/src/PgManyToManyRelationPlugin.js
@@ -424,17 +424,19 @@ module.exports = function PgManyToManyRelationPlugin(builder, options) {
         junctionLeftConstraint,
         junctionRightConstraint
       ) {
-        const relationName = inflection.manyToManyRelationByKeys(
-          leftKeyAttributes,
-          junctionLeftKeyAttributes,
-          junctionRightKeyAttributes,
-          rightKeyAttributes,
-          junctionTable,
-          rightTable,
-          junctionLeftConstraint,
-          junctionRightConstraint
-        );
-        return this.upperCamelCase(`${relationName}-edge`);
+        const baseName =
+          junctionRightConstraint.tags.manyToManyObjectTypeBaseName ||
+          inflection.manyToManyRelationByKeys(
+            leftKeyAttributes,
+            junctionLeftKeyAttributes,
+            junctionRightKeyAttributes,
+            rightKeyAttributes,
+            junctionTable,
+            rightTable,
+            junctionLeftConstraint,
+            junctionRightConstraint
+          );
+        return this.upperCamelCase(`${baseName}-edge`);
       },
       manyToManyRelationConnection(
         leftKeyAttributes,
@@ -446,17 +448,19 @@ module.exports = function PgManyToManyRelationPlugin(builder, options) {
         junctionLeftConstraint,
         junctionRightConstraint
       ) {
-        const relationName = inflection.manyToManyRelationByKeys(
-          leftKeyAttributes,
-          junctionLeftKeyAttributes,
-          junctionRightKeyAttributes,
-          rightKeyAttributes,
-          junctionTable,
-          rightTable,
-          junctionLeftConstraint,
-          junctionRightConstraint
-        );
-        return this.upperCamelCase(`${relationName}-connection`);
+        const baseName =
+          junctionRightConstraint.tags.manyToManyObjectTypeBaseName ||
+          inflection.manyToManyRelationByKeys(
+            leftKeyAttributes,
+            junctionLeftKeyAttributes,
+            junctionRightKeyAttributes,
+            rightKeyAttributes,
+            junctionTable,
+            rightTable,
+            junctionLeftConstraint,
+            junctionRightConstraint
+          );
+        return this.upperCamelCase(`${baseName}-connection`);
       },
     });
   });

--- a/src/PgManyToManyRelationPlugin.js
+++ b/src/PgManyToManyRelationPlugin.js
@@ -455,8 +455,8 @@ module.exports = function PgManyToManyRelationPlugin(builder, options) {
         _rightKeyAttributes,
         junctionTable,
         rightTable,
-        _junctionLeftConstraint,
-        _junctionRightConstraint
+        _junctionLeftConstraint, // eslint-disable-line no-unused-vars
+        _junctionRightConstraint // eslint-disable-line no-unused-vars
       ) {
         return this.camelCase(
           `${this.pluralize(
@@ -476,8 +476,8 @@ module.exports = function PgManyToManyRelationPlugin(builder, options) {
         _rightKeyAttributes,
         junctionTable,
         rightTable,
-        _junctionLeftConstraint,
-        _junctionRightConstraint
+        _junctionLeftConstraint, // eslint-disable-line no-unused-vars
+        _junctionRightConstraint // eslint-disable-line no-unused-vars
       ) {
         return this.camelCase(
           `${this.pluralize(


### PR DESCRIPTION
If multiple different database tables used the same `@manyToManyFieldName` smart comment, the edge object types and connection object types would have name conflicts. This pull request introduces a new `@manyToManyObjectTypeBaseName` smart comment that allows you to resolve these name conflicts.

This pull request also moves all smart comment processing outside of the `inflection` functions. If people want to write custom inflectors (as suggested by the README), they should not have to worry about processing smart comments. Note that [the `inflections.js` file in the `graphile-build-pg` package](https://github.com/singingwolfboy/graphile-engine/blob/master/packages/graphile-build-pg/src/inflections.js) does not process smart comments in the inflector code -- we should follow that example.