### PR TITLE
Add typescript type declarations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,3 @@
+declare const PgManyToManyPlugin: import("graphile-build").Plugin;
+export default PgManyToManyPlugin;
+


### PR DESCRIPTION
Adds built-in type declarations for TypeScript users. I copied the approach from here: https://github.com/graphile/pg-simplify-inflector/blob/master/index.d.ts

Verified that adding this file to my local `node_modules` folder resolved type issues I had encountered prior.