### PR TITLE
fix(types): include index.d.ts in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Add connection fields for many-to-many relations",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "lint": "eslint .",
     "test": "scripts/test"
@@ -35,7 +36,8 @@
     ]
   },
   "files": [
-    "src"
+    "src",
+    "index.d.ts"
   ],
   "engines": {
     "node": ">=10"


### PR DESCRIPTION
Looks like the `index.d.ts` file is [not included in the bundle](https://unpkg.com/browse/@graphile-contrib/pg-many-to-many@1.0.0/), so TypeScript can't see it - hence #55 

This fixes #55 (hopefully) by including the index.d.ts file in the bundle.