### PR TITLE
feat: Enable customization through a relationship filter

### DIFF
--- a/src/PgManyToManyRelationPlugin.js
+++ b/src/PgManyToManyRelationPlugin.js
@@ -15,6 +15,7 @@ module.exports = function PgManyToManyRelationPlugin(builder, options) {
       pgQueryFromResolveData: queryFromResolveData,
       pgAddStartEndCursor: addStartEndCursor,
       describePgEntity,
+      pgManyToManyFilter,
     } = build;
     const {
       scope: { isPgRowType, pgIntrospection: leftTable },
@@ -25,7 +26,11 @@ module.exports = function PgManyToManyRelationPlugin(builder, options) {
       return fields;
     }
 
-    const relationships = manyToManyRelationships(leftTable, build);
+    const relationships = manyToManyRelationships(leftTable, build).filter(
+      (relationship) =>
+        pgManyToManyFilter === undefined ||
+        pgManyToManyFilter(leftTable, relationship)
+    );
     return extend(
       fields,
       relationships.reduce((memo, relationship) => {

--- a/src/PgManyToManyRelationPlugin.js
+++ b/src/PgManyToManyRelationPlugin.js
@@ -2,7 +2,7 @@ const createManyToManyConnectionType = require("./createManyToManyConnectionType
 const manyToManyRelationships = require("./manyToManyRelationships");
 
 module.exports = function PgManyToManyRelationPlugin(builder, options) {
-  const { pgSimpleCollections } = options;
+  const { pgSimpleCollections, pgManyToManyFilter } = options;
   builder.hook("GraphQLObjectType:fields", (fields, build, context) => {
     const {
       extend,
@@ -15,7 +15,6 @@ module.exports = function PgManyToManyRelationPlugin(builder, options) {
       pgQueryFromResolveData: queryFromResolveData,
       pgAddStartEndCursor: addStartEndCursor,
       describePgEntity,
-      pgManyToManyFilter,
     } = build;
     const {
       scope: { isPgRowType, pgIntrospection: leftTable },


### PR DESCRIPTION
I had originally opened an issue, but thought it would be better to POC the change I was hoping for and see if this is something worth getting into the main branch.

# The problem

We would like to use the pg-many-to-many plugin to enable relationships between linker tables. While the plugin does work for this, it also ends up creating a lot of relationships based on constraints across all the tables we have which result in very verbose resolver names, such as `entityByEntityAIdAndEntityBIdAndEntityCId`, etc.

The `@omit manyToMany` option does allow us to remove these resolvers, but because its opt-out first, we are having to do this on most constraints and it makes the growing schema difficult to manage, as it becomes a requirement that we can't forget to do.

# Proposal

Allow consumers to pass a filter function that can let them decide when the derived relationship should result in a valid `manyToMany` connection. This function, here called `pgManyToManyFilter`, is backwards compatible and opt-in, so it has no downstream effects on existing usages.

An example of the usage, in the case of only wanting to enable for relationships where the linker table has a composite primary key, would look like:

```ts
...
graphileBuildOptions: {
    pgManyToManyFilter(
      leftTable: PostgraphileIntrospection,
      { junctionTable }: { junctionTable: PostgraphileIntrospection },
    ) {
      return (
        junctionTable.primaryKeyConstraint !== undefined &&
        junctionTable.primaryKeyConstraint.keyAttributes.length > 1
      )
    },
  },
...
```

I did not add any tests to validate this proposal, as I wasn't sure if it would be accepted as is, but I'd be happy to do so. We are currently consuming my fork, but I would prefer to get this change (or something similar) into the primary repo so we can point back to it.

Thanks again for contributing to OSS!