### PR TITLE
chore(deps): update `graphql` to 15.8.0

### DIFF
--- a/__tests__/integration/schema/__snapshots__/a.test.js.snap
+++ b/__tests__/integration/schema/__snapshots__/a.test.js.snap
@@ -2,15 +2,17 @@
 
 exports[`prints a schema using the 'a' database schema 1`] = `
 "type Bar implements Node {
-  """
-  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  """
-  nodeId: ID!
   barId: Int!
   barName: String!
 
-  """Reads and enables pagination through a set of \`Junction\`."""
-  junctionsByJBarId(
+  """Reads and enables pagination through a set of \`Foo\`."""
+  foosByJunctionJBarIdAndJFooId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -18,55 +20,52 @@ exports[`prints a schema using the 'a' database schema 1`] = `
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
+
+    """The method to use when ordering \`Foo\`."""
+    orderBy: [FoosOrderBy!] = [PRIMARY_KEY_ASC]
+  ): BarFoosByJunctionJBarIdAndJFooIdManyToManyConnection!
+
+  """Reads and enables pagination through a set of \`Junction\`."""
+  junctionsByJBarId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
 
     """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
+    """
+    offset: Int
 
     """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection!
 
-  """Reads and enables pagination through a set of \`Foo\`."""
-  foosByJunctionJBarIdAndJFooId(
-    """Only read the first \`n\` values of the set."""
-    first: Int
-
-    """Only read the last \`n\` values of the set."""
-    last: Int
-
-    """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
-    """The method to use when ordering \`Foo\`."""
-    orderBy: [FoosOrderBy!] = [PRIMARY_KEY_ASC]
-  ): BarFoosByJunctionJBarIdAndJFooIdManyToManyConnection!
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
 }
 
 """A connection to a list of \`Foo\` values, with data from \`Junction\`."""
 type BarFoosByJunctionJBarIdAndJFooIdManyToManyConnection {
-  """A list of \`Foo\` objects."""
-  nodes: [Foo]!
-
   """
   A list of edges which contains the \`Foo\`, info from the \`Junction\`, and the cursor to aid in pagination.
   """
   edges: [BarFoosByJunctionJBarIdAndJFooIdManyToManyEdge!]!
+
+  """A list of \`Foo\` objects."""
+  nodes: [Foo]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -86,13 +85,13 @@ type BarFoosByJunctionJBarIdAndJFooIdManyToManyEdge {
 
 """A connection to a list of \`Bar\` values."""
 type BarsConnection {
-  """A list of \`Bar\` objects."""
-  nodes: [Bar]!
-
   """
   A list of edges which contains the \`Bar\` and cursor to aid in pagination.
   """
   edges: [BarsEdge!]!
+
+  """A list of \`Bar\` objects."""
+  nodes: [Bar]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -112,11 +111,11 @@ type BarsEdge {
 
 """Methods to use when ordering \`Bar\`."""
 enum BarsOrderBy {
-  NATURAL
   BAR_ID_ASC
   BAR_ID_DESC
   BAR_NAME_ASC
   BAR_NAME_DESC
+  NATURAL
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
@@ -125,15 +124,39 @@ enum BarsOrderBy {
 scalar Cursor
 
 type Foo implements Node {
-  """
-  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  """
-  nodeId: ID!
+  """Reads and enables pagination through a set of \`Bar\`."""
+  barsByJunctionJFooIdAndJBarId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Bar\`."""
+    orderBy: [BarsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): FooBarsByJunctionJFooIdAndJBarIdManyToManyConnection!
   fooId: Int!
   fooName: String!
 
   """Reads and enables pagination through a set of \`Junction\`."""
   junctionsByJFooId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -141,55 +164,29 @@ type Foo implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
 
     """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection!
 
-  """Reads and enables pagination through a set of \`Bar\`."""
-  barsByJunctionJFooIdAndJBarId(
-    """Only read the first \`n\` values of the set."""
-    first: Int
-
-    """Only read the last \`n\` values of the set."""
-    last: Int
-
-    """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
-    """The method to use when ordering \`Bar\`."""
-    orderBy: [BarsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): FooBarsByJunctionJFooIdAndJBarIdManyToManyConnection!
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
 }
 
 """A connection to a list of \`Bar\` values, with data from \`Junction\`."""
 type FooBarsByJunctionJFooIdAndJBarIdManyToManyConnection {
-  """A list of \`Bar\` objects."""
-  nodes: [Bar]!
-
   """
   A list of edges which contains the \`Bar\`, info from the \`Junction\`, and the cursor to aid in pagination.
   """
   edges: [FooBarsByJunctionJFooIdAndJBarIdManyToManyEdge!]!
+
+  """A list of \`Bar\` objects."""
+  nodes: [Bar]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -209,13 +206,13 @@ type FooBarsByJunctionJFooIdAndJBarIdManyToManyEdge {
 
 """A connection to a list of \`Foo\` values."""
 type FoosConnection {
-  """A list of \`Foo\` objects."""
-  nodes: [Foo]!
-
   """
   A list of edges which contains the \`Foo\` and cursor to aid in pagination.
   """
   edges: [FoosEdge!]!
+
+  """A list of \`Foo\` objects."""
+  nodes: [Foo]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -235,39 +232,39 @@ type FoosEdge {
 
 """Methods to use when ordering \`Foo\`."""
 enum FoosOrderBy {
-  NATURAL
   FOO_ID_ASC
   FOO_ID_DESC
   FOO_NAME_ASC
   FOO_NAME_DESC
+  NATURAL
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
 
 type Junction implements Node {
+  """Reads a single \`Bar\` that is related to this \`Junction\`."""
+  barByJBarId: Bar
+
+  """Reads a single \`Foo\` that is related to this \`Junction\`."""
+  fooByJFooId: Foo
+  jBarId: Int!
+  jFooId: Int!
+
   """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   """
   nodeId: ID!
-  jFooId: Int!
-  jBarId: Int!
-
-  """Reads a single \`Foo\` that is related to this \`Junction\`."""
-  fooByJFooId: Foo
-
-  """Reads a single \`Bar\` that is related to this \`Junction\`."""
-  barByJBarId: Bar
 }
 
 """A connection to a list of \`Junction\` values."""
 type JunctionsConnection {
-  """A list of \`Junction\` objects."""
-  nodes: [Junction]!
-
   """
   A list of edges which contains the \`Junction\` and cursor to aid in pagination.
   """
   edges: [JunctionsEdge!]!
+
+  """A list of \`Junction\` objects."""
+  nodes: [Junction]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -287,11 +284,11 @@ type JunctionsEdge {
 
 """Methods to use when ordering \`Junction\`."""
 enum JunctionsOrderBy {
-  NATURAL
-  J_FOO_ID_ASC
-  J_FOO_ID_DESC
   J_BAR_ID_ASC
   J_BAR_ID_DESC
+  J_FOO_ID_ASC
+  J_FOO_ID_DESC
+  NATURAL
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
@@ -306,6 +303,9 @@ interface Node {
 
 """Information about pagination in a connection."""
 type PageInfo {
+  """When paginating forwards, the cursor to continue."""
+  endCursor: Cursor
+
   """When paginating forwards, are there more items?"""
   hasNextPage: Boolean!
 
@@ -314,32 +314,18 @@ type PageInfo {
 
   """When paginating backwards, the cursor to continue."""
   startCursor: Cursor
-
-  """When paginating forwards, the cursor to continue."""
-  endCursor: Cursor
 }
 
 """The root query type which gives access points into the data universe."""
 type Query implements Node {
-  """
-  Exposes the root query type nested one level down. This is helpful for Relay 1
-  which can only query top level fields if they are in a particular form.
-  """
-  query: Query!
-
-  """
-  The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
-  """
-  nodeId: ID!
-
-  """Fetches an object given its globally unique \`ID\`."""
-  node(
-    """The globally unique \`ID\`."""
-    nodeId: ID!
-  ): Node
-
   """Reads and enables pagination through a set of \`Bar\`."""
   allBars(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -347,16 +333,9 @@ type Query implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
 
     """The method to use when ordering \`Bar\`."""
     orderBy: [BarsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -364,6 +343,12 @@ type Query implements Node {
 
   """Reads and enables pagination through a set of \`Foo\`."""
   allFoos(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -371,16 +356,9 @@ type Query implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
 
     """The method to use when ordering \`Foo\`."""
     orderBy: [FoosOrderBy!] = [PRIMARY_KEY_ASC]
@@ -388,6 +366,12 @@ type Query implements Node {
 
   """Reads and enables pagination through a set of \`Junction\`."""
   allJunctions(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -395,41 +379,50 @@ type Query implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
 
     """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection
-  barByBarId(barId: Int!): Bar
-  fooByFooId(fooId: Int!): Foo
-  junctionByJFooIdAndJBarId(jFooId: Int!, jBarId: Int!): Junction
 
   """Reads a single \`Bar\` using its globally unique \`ID\`."""
   bar(
     """The globally unique \`ID\` to be used in selecting a single \`Bar\`."""
     nodeId: ID!
   ): Bar
+  barByBarId(barId: Int!): Bar
 
   """Reads a single \`Foo\` using its globally unique \`ID\`."""
   foo(
     """The globally unique \`ID\` to be used in selecting a single \`Foo\`."""
     nodeId: ID!
   ): Foo
+  fooByFooId(fooId: Int!): Foo
 
   """Reads a single \`Junction\` using its globally unique \`ID\`."""
   junction(
     """The globally unique \`ID\` to be used in selecting a single \`Junction\`."""
     nodeId: ID!
   ): Junction
+  junctionByJFooIdAndJBarId(jBarId: Int!, jFooId: Int!): Junction
+
+  """Fetches an object given its globally unique \`ID\`."""
+  node(
+    """The globally unique \`ID\`."""
+    nodeId: ID!
+  ): Node
+
+  """
+  The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
+  """
+  nodeId: ID!
+
+  """
+  Exposes the root query type nested one level down. This is helpful for Relay 1 which can only query top level fields if they are in a particular form.
+  """
+  query: Query!
 }
 "
 `;

--- a/__tests__/integration/schema/__snapshots__/b.test.js.snap
+++ b/__tests__/integration/schema/__snapshots__/b.test.js.snap
@@ -2,15 +2,17 @@
 
 exports[`prints a schema using the 'b' database schema 1`] = `
 "type Bar implements Node {
-  """
-  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  """
-  nodeId: ID!
   barId: Int!
   barName: String!
 
-  """Reads and enables pagination through a set of \`Junction\`."""
-  junctionsByJBarId(
+  """Reads and enables pagination through a set of \`Foo\`."""
+  foosByJunctionJBarIdAndJFooId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -18,55 +20,52 @@ exports[`prints a schema using the 'b' database schema 1`] = `
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
+
+    """The method to use when ordering \`Foo\`."""
+    orderBy: [FoosOrderBy!] = [PRIMARY_KEY_ASC]
+  ): BarFoosByJunctionJBarIdAndJFooIdManyToManyConnection!
+
+  """Reads and enables pagination through a set of \`Junction\`."""
+  junctionsByJBarId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
 
     """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
+    """
+    offset: Int
 
     """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection!
 
-  """Reads and enables pagination through a set of \`Foo\`."""
-  foosByJunctionJBarIdAndJFooId(
-    """Only read the first \`n\` values of the set."""
-    first: Int
-
-    """Only read the last \`n\` values of the set."""
-    last: Int
-
-    """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
-    """The method to use when ordering \`Foo\`."""
-    orderBy: [FoosOrderBy!] = [PRIMARY_KEY_ASC]
-  ): BarFoosByJunctionJBarIdAndJFooIdManyToManyConnection!
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
 }
 
 """A connection to a list of \`Foo\` values, with data from \`Junction\`."""
 type BarFoosByJunctionJBarIdAndJFooIdManyToManyConnection {
-  """A list of \`Foo\` objects."""
-  nodes: [Foo]!
-
   """
   A list of edges which contains the \`Foo\`, info from the \`Junction\`, and the cursor to aid in pagination.
   """
   edges: [BarFoosByJunctionJBarIdAndJFooIdManyToManyEdge!]!
+
+  """A list of \`Foo\` objects."""
+  nodes: [Foo]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -77,23 +76,24 @@ type BarFoosByJunctionJBarIdAndJFooIdManyToManyConnection {
 
 """A \`Foo\` edge in the connection, with data from \`Junction\`."""
 type BarFoosByJunctionJBarIdAndJFooIdManyToManyEdge {
+  createdAt: Datetime!
+
   """A cursor for use in pagination."""
   cursor: Cursor
 
   """The \`Foo\` at the end of the edge."""
   node: Foo
-  createdAt: Datetime!
 }
 
 """A connection to a list of \`Bar\` values."""
 type BarsConnection {
-  """A list of \`Bar\` objects."""
-  nodes: [Bar]!
-
   """
   A list of edges which contains the \`Bar\` and cursor to aid in pagination.
   """
   edges: [BarsEdge!]!
+
+  """A list of \`Bar\` objects."""
+  nodes: [Bar]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -113,11 +113,11 @@ type BarsEdge {
 
 """Methods to use when ordering \`Bar\`."""
 enum BarsOrderBy {
-  NATURAL
   BAR_ID_ASC
   BAR_ID_DESC
   BAR_NAME_ASC
   BAR_NAME_DESC
+  NATURAL
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
@@ -126,21 +126,44 @@ enum BarsOrderBy {
 scalar Cursor
 
 """
-A point in time as described by the [ISO
-8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
+A point in time as described by the [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
 """
 scalar Datetime
 
 type Foo implements Node {
-  """
-  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  """
-  nodeId: ID!
+  """Reads and enables pagination through a set of \`Bar\`."""
+  barsByJunctionJFooIdAndJBarId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Bar\`."""
+    orderBy: [BarsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): FooBarsByJunctionJFooIdAndJBarIdManyToManyConnection!
   fooId: Int!
   fooName: String!
 
   """Reads and enables pagination through a set of \`Junction\`."""
   junctionsByJFooId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -148,55 +171,29 @@ type Foo implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
 
     """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection!
 
-  """Reads and enables pagination through a set of \`Bar\`."""
-  barsByJunctionJFooIdAndJBarId(
-    """Only read the first \`n\` values of the set."""
-    first: Int
-
-    """Only read the last \`n\` values of the set."""
-    last: Int
-
-    """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
-    """The method to use when ordering \`Bar\`."""
-    orderBy: [BarsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): FooBarsByJunctionJFooIdAndJBarIdManyToManyConnection!
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
 }
 
 """A connection to a list of \`Bar\` values, with data from \`Junction\`."""
 type FooBarsByJunctionJFooIdAndJBarIdManyToManyConnection {
-  """A list of \`Bar\` objects."""
-  nodes: [Bar]!
-
   """
   A list of edges which contains the \`Bar\`, info from the \`Junction\`, and the cursor to aid in pagination.
   """
   edges: [FooBarsByJunctionJFooIdAndJBarIdManyToManyEdge!]!
+
+  """A list of \`Bar\` objects."""
+  nodes: [Bar]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -207,23 +204,24 @@ type FooBarsByJunctionJFooIdAndJBarIdManyToManyConnection {
 
 """A \`Bar\` edge in the connection, with data from \`Junction\`."""
 type FooBarsByJunctionJFooIdAndJBarIdManyToManyEdge {
+  createdAt: Datetime!
+
   """A cursor for use in pagination."""
   cursor: Cursor
 
   """The \`Bar\` at the end of the edge."""
   node: Bar
-  createdAt: Datetime!
 }
 
 """A connection to a list of \`Foo\` values."""
 type FoosConnection {
-  """A list of \`Foo\` objects."""
-  nodes: [Foo]!
-
   """
   A list of edges which contains the \`Foo\` and cursor to aid in pagination.
   """
   edges: [FoosEdge!]!
+
+  """A list of \`Foo\` objects."""
+  nodes: [Foo]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -243,40 +241,40 @@ type FoosEdge {
 
 """Methods to use when ordering \`Foo\`."""
 enum FoosOrderBy {
-  NATURAL
   FOO_ID_ASC
   FOO_ID_DESC
   FOO_NAME_ASC
   FOO_NAME_DESC
+  NATURAL
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
 
 type Junction implements Node {
-  """
-  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  """
-  nodeId: ID!
-  jFooId: Int!
-  jBarId: Int!
+  """Reads a single \`Bar\` that is related to this \`Junction\`."""
+  barByJBarId: Bar
   createdAt: Datetime!
 
   """Reads a single \`Foo\` that is related to this \`Junction\`."""
   fooByJFooId: Foo
+  jBarId: Int!
+  jFooId: Int!
 
-  """Reads a single \`Bar\` that is related to this \`Junction\`."""
-  barByJBarId: Bar
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
 }
 
 """A connection to a list of \`Junction\` values."""
 type JunctionsConnection {
-  """A list of \`Junction\` objects."""
-  nodes: [Junction]!
-
   """
   A list of edges which contains the \`Junction\` and cursor to aid in pagination.
   """
   edges: [JunctionsEdge!]!
+
+  """A list of \`Junction\` objects."""
+  nodes: [Junction]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -296,13 +294,13 @@ type JunctionsEdge {
 
 """Methods to use when ordering \`Junction\`."""
 enum JunctionsOrderBy {
-  NATURAL
-  J_FOO_ID_ASC
-  J_FOO_ID_DESC
-  J_BAR_ID_ASC
-  J_BAR_ID_DESC
   CREATED_AT_ASC
   CREATED_AT_DESC
+  J_BAR_ID_ASC
+  J_BAR_ID_DESC
+  J_FOO_ID_ASC
+  J_FOO_ID_DESC
+  NATURAL
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
@@ -317,6 +315,9 @@ interface Node {
 
 """Information about pagination in a connection."""
 type PageInfo {
+  """When paginating forwards, the cursor to continue."""
+  endCursor: Cursor
+
   """When paginating forwards, are there more items?"""
   hasNextPage: Boolean!
 
@@ -325,32 +326,18 @@ type PageInfo {
 
   """When paginating backwards, the cursor to continue."""
   startCursor: Cursor
-
-  """When paginating forwards, the cursor to continue."""
-  endCursor: Cursor
 }
 
 """The root query type which gives access points into the data universe."""
 type Query implements Node {
-  """
-  Exposes the root query type nested one level down. This is helpful for Relay 1
-  which can only query top level fields if they are in a particular form.
-  """
-  query: Query!
-
-  """
-  The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
-  """
-  nodeId: ID!
-
-  """Fetches an object given its globally unique \`ID\`."""
-  node(
-    """The globally unique \`ID\`."""
-    nodeId: ID!
-  ): Node
-
   """Reads and enables pagination through a set of \`Bar\`."""
   allBars(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -358,16 +345,9 @@ type Query implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
 
     """The method to use when ordering \`Bar\`."""
     orderBy: [BarsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -375,6 +355,12 @@ type Query implements Node {
 
   """Reads and enables pagination through a set of \`Foo\`."""
   allFoos(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -382,16 +368,9 @@ type Query implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
 
     """The method to use when ordering \`Foo\`."""
     orderBy: [FoosOrderBy!] = [PRIMARY_KEY_ASC]
@@ -399,6 +378,12 @@ type Query implements Node {
 
   """Reads and enables pagination through a set of \`Junction\`."""
   allJunctions(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -406,41 +391,50 @@ type Query implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
 
     """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection
-  barByBarId(barId: Int!): Bar
-  fooByFooId(fooId: Int!): Foo
-  junctionByJFooIdAndJBarId(jFooId: Int!, jBarId: Int!): Junction
 
   """Reads a single \`Bar\` using its globally unique \`ID\`."""
   bar(
     """The globally unique \`ID\` to be used in selecting a single \`Bar\`."""
     nodeId: ID!
   ): Bar
+  barByBarId(barId: Int!): Bar
 
   """Reads a single \`Foo\` using its globally unique \`ID\`."""
   foo(
     """The globally unique \`ID\` to be used in selecting a single \`Foo\`."""
     nodeId: ID!
   ): Foo
+  fooByFooId(fooId: Int!): Foo
 
   """Reads a single \`Junction\` using its globally unique \`ID\`."""
   junction(
     """The globally unique \`ID\` to be used in selecting a single \`Junction\`."""
     nodeId: ID!
   ): Junction
+  junctionByJFooIdAndJBarId(jBarId: Int!, jFooId: Int!): Junction
+
+  """Fetches an object given its globally unique \`ID\`."""
+  node(
+    """The globally unique \`ID\`."""
+    nodeId: ID!
+  ): Node
+
+  """
+  The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
+  """
+  nodeId: ID!
+
+  """
+  Exposes the root query type nested one level down. This is helpful for Relay 1 which can only query top level fields if they are in a particular form.
+  """
+  query: Query!
 }
 "
 `;

--- a/__tests__/integration/schema/__snapshots__/c.test.js.snap
+++ b/__tests__/integration/schema/__snapshots__/c.test.js.snap
@@ -2,15 +2,17 @@
 
 exports[`prints a schema using the 'c' database schema 1`] = `
 "type Bar implements Node {
-  """
-  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  """
-  nodeId: ID!
   barId: Int!
   barName: String!
 
-  """Reads and enables pagination through a set of \`Junction\`."""
-  junctionsByJBarId(
+  """Reads and enables pagination through a set of \`Foo\`."""
+  foosByJunctionJBarIdAndJFooId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -18,55 +20,52 @@ exports[`prints a schema using the 'c' database schema 1`] = `
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
+
+    """The method to use when ordering \`Foo\`."""
+    orderBy: [FoosOrderBy!] = [PRIMARY_KEY_ASC]
+  ): BarFoosByJunctionJBarIdAndJFooIdManyToManyConnection!
+
+  """Reads and enables pagination through a set of \`Junction\`."""
+  junctionsByJBarId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
 
     """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
+    """
+    offset: Int
 
     """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection!
 
-  """Reads and enables pagination through a set of \`Foo\`."""
-  foosByJunctionJBarIdAndJFooId(
-    """Only read the first \`n\` values of the set."""
-    first: Int
-
-    """Only read the last \`n\` values of the set."""
-    last: Int
-
-    """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
-    """The method to use when ordering \`Foo\`."""
-    orderBy: [FoosOrderBy!] = [PRIMARY_KEY_ASC]
-  ): BarFoosByJunctionJBarIdAndJFooIdManyToManyConnection!
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
 }
 
 """A connection to a list of \`Foo\` values, with data from \`Junction\`."""
 type BarFoosByJunctionJBarIdAndJFooIdManyToManyConnection {
-  """A list of \`Foo\` objects."""
-  nodes: [Foo]!
-
   """
   A list of edges which contains the \`Foo\`, info from the \`Junction\`, and the cursor to aid in pagination.
   """
   edges: [BarFoosByJunctionJBarIdAndJFooIdManyToManyEdge!]!
+
+  """A list of \`Foo\` objects."""
+  nodes: [Foo]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -80,11 +79,14 @@ type BarFoosByJunctionJBarIdAndJFooIdManyToManyEdge {
   """A cursor for use in pagination."""
   cursor: Cursor
 
-  """The \`Foo\` at the end of the edge."""
-  node: Foo
-
   """Reads and enables pagination through a set of \`Junction\`."""
   junctionsByJFooId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -92,31 +94,27 @@ type BarFoosByJunctionJBarIdAndJFooIdManyToManyEdge {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
 
     """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection!
+
+  """The \`Foo\` at the end of the edge."""
+  node: Foo
 }
 
 """A connection to a list of \`Bar\` values."""
 type BarsConnection {
-  """A list of \`Bar\` objects."""
-  nodes: [Bar]!
-
   """
   A list of edges which contains the \`Bar\` and cursor to aid in pagination.
   """
   edges: [BarsEdge!]!
+
+  """A list of \`Bar\` objects."""
+  nodes: [Bar]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -136,11 +134,11 @@ type BarsEdge {
 
 """Methods to use when ordering \`Bar\`."""
 enum BarsOrderBy {
-  NATURAL
   BAR_ID_ASC
   BAR_ID_DESC
   BAR_NAME_ASC
   BAR_NAME_DESC
+  NATURAL
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
@@ -149,15 +147,39 @@ enum BarsOrderBy {
 scalar Cursor
 
 type Foo implements Node {
-  """
-  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  """
-  nodeId: ID!
+  """Reads and enables pagination through a set of \`Bar\`."""
+  barsByJunctionJFooIdAndJBarId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Bar\`."""
+    orderBy: [BarsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): FooBarsByJunctionJFooIdAndJBarIdManyToManyConnection!
   fooId: Int!
   fooName: String!
 
   """Reads and enables pagination through a set of \`Junction\`."""
   junctionsByJFooId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -165,55 +187,29 @@ type Foo implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
 
     """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection!
 
-  """Reads and enables pagination through a set of \`Bar\`."""
-  barsByJunctionJFooIdAndJBarId(
-    """Only read the first \`n\` values of the set."""
-    first: Int
-
-    """Only read the last \`n\` values of the set."""
-    last: Int
-
-    """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
-    """The method to use when ordering \`Bar\`."""
-    orderBy: [BarsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): FooBarsByJunctionJFooIdAndJBarIdManyToManyConnection!
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
 }
 
 """A connection to a list of \`Bar\` values, with data from \`Junction\`."""
 type FooBarsByJunctionJFooIdAndJBarIdManyToManyConnection {
-  """A list of \`Bar\` objects."""
-  nodes: [Bar]!
-
   """
   A list of edges which contains the \`Bar\`, info from the \`Junction\`, and the cursor to aid in pagination.
   """
   edges: [FooBarsByJunctionJFooIdAndJBarIdManyToManyEdge!]!
+
+  """A list of \`Bar\` objects."""
+  nodes: [Bar]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -227,11 +223,14 @@ type FooBarsByJunctionJFooIdAndJBarIdManyToManyEdge {
   """A cursor for use in pagination."""
   cursor: Cursor
 
-  """The \`Bar\` at the end of the edge."""
-  node: Bar
-
   """Reads and enables pagination through a set of \`Junction\`."""
   junctionsByJBarId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -239,31 +238,27 @@ type FooBarsByJunctionJFooIdAndJBarIdManyToManyEdge {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
 
     """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection!
+
+  """The \`Bar\` at the end of the edge."""
+  node: Bar
 }
 
 """A connection to a list of \`Foo\` values."""
 type FoosConnection {
-  """A list of \`Foo\` objects."""
-  nodes: [Foo]!
-
   """
   A list of edges which contains the \`Foo\` and cursor to aid in pagination.
   """
   edges: [FoosEdge!]!
+
+  """A list of \`Foo\` objects."""
+  nodes: [Foo]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -283,40 +278,40 @@ type FoosEdge {
 
 """Methods to use when ordering \`Foo\`."""
 enum FoosOrderBy {
-  NATURAL
   FOO_ID_ASC
   FOO_ID_DESC
   FOO_NAME_ASC
   FOO_NAME_DESC
+  NATURAL
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
 
 type Junction implements Node {
+  """Reads a single \`Bar\` that is related to this \`Junction\`."""
+  barByJBarId: Bar
+
+  """Reads a single \`Foo\` that is related to this \`Junction\`."""
+  fooByJFooId: Foo
+  id: Int!
+  jBarId: Int
+  jFooId: Int
+
   """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   """
   nodeId: ID!
-  id: Int!
-  jFooId: Int
-  jBarId: Int
-
-  """Reads a single \`Foo\` that is related to this \`Junction\`."""
-  fooByJFooId: Foo
-
-  """Reads a single \`Bar\` that is related to this \`Junction\`."""
-  barByJBarId: Bar
 }
 
 """A connection to a list of \`Junction\` values."""
 type JunctionsConnection {
-  """A list of \`Junction\` objects."""
-  nodes: [Junction]!
-
   """
   A list of edges which contains the \`Junction\` and cursor to aid in pagination.
   """
   edges: [JunctionsEdge!]!
+
+  """A list of \`Junction\` objects."""
+  nodes: [Junction]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -336,13 +331,13 @@ type JunctionsEdge {
 
 """Methods to use when ordering \`Junction\`."""
 enum JunctionsOrderBy {
-  NATURAL
   ID_ASC
   ID_DESC
-  J_FOO_ID_ASC
-  J_FOO_ID_DESC
   J_BAR_ID_ASC
   J_BAR_ID_DESC
+  J_FOO_ID_ASC
+  J_FOO_ID_DESC
+  NATURAL
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
@@ -357,6 +352,9 @@ interface Node {
 
 """Information about pagination in a connection."""
 type PageInfo {
+  """When paginating forwards, the cursor to continue."""
+  endCursor: Cursor
+
   """When paginating forwards, are there more items?"""
   hasNextPage: Boolean!
 
@@ -365,32 +363,18 @@ type PageInfo {
 
   """When paginating backwards, the cursor to continue."""
   startCursor: Cursor
-
-  """When paginating forwards, the cursor to continue."""
-  endCursor: Cursor
 }
 
 """The root query type which gives access points into the data universe."""
 type Query implements Node {
-  """
-  Exposes the root query type nested one level down. This is helpful for Relay 1
-  which can only query top level fields if they are in a particular form.
-  """
-  query: Query!
-
-  """
-  The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
-  """
-  nodeId: ID!
-
-  """Fetches an object given its globally unique \`ID\`."""
-  node(
-    """The globally unique \`ID\`."""
-    nodeId: ID!
-  ): Node
-
   """Reads and enables pagination through a set of \`Bar\`."""
   allBars(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -398,16 +382,9 @@ type Query implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
 
     """The method to use when ordering \`Bar\`."""
     orderBy: [BarsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -415,6 +392,12 @@ type Query implements Node {
 
   """Reads and enables pagination through a set of \`Foo\`."""
   allFoos(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -422,16 +405,9 @@ type Query implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
 
     """The method to use when ordering \`Foo\`."""
     orderBy: [FoosOrderBy!] = [PRIMARY_KEY_ASC]
@@ -439,6 +415,12 @@ type Query implements Node {
 
   """Reads and enables pagination through a set of \`Junction\`."""
   allJunctions(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -446,41 +428,50 @@ type Query implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
 
     """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection
-  barByBarId(barId: Int!): Bar
-  fooByFooId(fooId: Int!): Foo
-  junctionById(id: Int!): Junction
 
   """Reads a single \`Bar\` using its globally unique \`ID\`."""
   bar(
     """The globally unique \`ID\` to be used in selecting a single \`Bar\`."""
     nodeId: ID!
   ): Bar
+  barByBarId(barId: Int!): Bar
 
   """Reads a single \`Foo\` using its globally unique \`ID\`."""
   foo(
     """The globally unique \`ID\` to be used in selecting a single \`Foo\`."""
     nodeId: ID!
   ): Foo
+  fooByFooId(fooId: Int!): Foo
 
   """Reads a single \`Junction\` using its globally unique \`ID\`."""
   junction(
     """The globally unique \`ID\` to be used in selecting a single \`Junction\`."""
     nodeId: ID!
   ): Junction
+  junctionById(id: Int!): Junction
+
+  """Fetches an object given its globally unique \`ID\`."""
+  node(
+    """The globally unique \`ID\`."""
+    nodeId: ID!
+  ): Node
+
+  """
+  The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
+  """
+  nodeId: ID!
+
+  """
+  Exposes the root query type nested one level down. This is helpful for Relay 1 which can only query top level fields if they are in a particular form.
+  """
+  query: Query!
 }
 "
 `;

--- a/__tests__/integration/schema/__snapshots__/d.test.js.snap
+++ b/__tests__/integration/schema/__snapshots__/d.test.js.snap
@@ -2,15 +2,17 @@
 
 exports[`prints a schema using the 'd' database schema 1`] = `
 "type Bar implements Node {
-  """
-  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  """
-  nodeId: ID!
   barId: Int!
   barName: String!
 
-  """Reads and enables pagination through a set of \`Junction\`."""
-  junctionsByJBarId(
+  """Reads and enables pagination through a set of \`Foo\`."""
+  foosByJunctionJBarIdAndJFooId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -18,55 +20,52 @@ exports[`prints a schema using the 'd' database schema 1`] = `
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
+
+    """The method to use when ordering \`Foo\`."""
+    orderBy: [FoosOrderBy!] = [PRIMARY_KEY_ASC]
+  ): BarFoosByJunctionJBarIdAndJFooIdManyToManyConnection!
+
+  """Reads and enables pagination through a set of \`Junction\`."""
+  junctionsByJBarId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
 
     """Read all values in the set before (above) this cursor."""
     before: Cursor
 
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
+    """
+    offset: Int
 
     """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection!
 
-  """Reads and enables pagination through a set of \`Foo\`."""
-  foosByJunctionJBarIdAndJFooId(
-    """Only read the first \`n\` values of the set."""
-    first: Int
-
-    """Only read the last \`n\` values of the set."""
-    last: Int
-
-    """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
-    """The method to use when ordering \`Foo\`."""
-    orderBy: [FoosOrderBy!] = [PRIMARY_KEY_ASC]
-  ): BarFoosByJunctionJBarIdAndJFooIdManyToManyConnection!
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
 }
 
 """A connection to a list of \`Foo\` values, with data from \`Junction\`."""
 type BarFoosByJunctionJBarIdAndJFooIdManyToManyConnection {
-  """A list of \`Foo\` objects."""
-  nodes: [Foo]!
-
   """
   A list of edges which contains the \`Foo\`, info from the \`Junction\`, and the cursor to aid in pagination.
   """
   edges: [BarFoosByJunctionJBarIdAndJFooIdManyToManyEdge!]!
+
+  """A list of \`Foo\` objects."""
+  nodes: [Foo]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -80,11 +79,14 @@ type BarFoosByJunctionJBarIdAndJFooIdManyToManyEdge {
   """A cursor for use in pagination."""
   cursor: Cursor
 
-  """The \`Foo\` at the end of the edge."""
-  node: Foo
-
   """Reads and enables pagination through a set of \`Junction\`."""
   junctionsByJFooId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -92,31 +94,27 @@ type BarFoosByJunctionJBarIdAndJFooIdManyToManyEdge {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
 
     """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection!
+
+  """The \`Foo\` at the end of the edge."""
+  node: Foo
 }
 
 """A connection to a list of \`Bar\` values."""
 type BarsConnection {
-  """A list of \`Bar\` objects."""
-  nodes: [Bar]!
-
   """
   A list of edges which contains the \`Bar\` and cursor to aid in pagination.
   """
   edges: [BarsEdge!]!
+
+  """A list of \`Bar\` objects."""
+  nodes: [Bar]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -136,11 +134,11 @@ type BarsEdge {
 
 """Methods to use when ordering \`Bar\`."""
 enum BarsOrderBy {
-  NATURAL
   BAR_ID_ASC
   BAR_ID_DESC
   BAR_NAME_ASC
   BAR_NAME_DESC
+  NATURAL
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
@@ -149,21 +147,44 @@ enum BarsOrderBy {
 scalar Cursor
 
 """
-A point in time as described by the [ISO
-8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
+A point in time as described by the [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
 """
 scalar Datetime
 
 type Foo implements Node {
-  """
-  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  """
-  nodeId: ID!
+  """Reads and enables pagination through a set of \`Bar\`."""
+  barsByJunctionJFooIdAndJBarId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Bar\`."""
+    orderBy: [BarsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): FooBarsByJunctionJFooIdAndJBarIdManyToManyConnection!
   fooId: Int!
   fooName: String!
 
   """Reads and enables pagination through a set of \`Junction\`."""
   junctionsByJFooId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -171,55 +192,29 @@ type Foo implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
 
     """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection!
 
-  """Reads and enables pagination through a set of \`Bar\`."""
-  barsByJunctionJFooIdAndJBarId(
-    """Only read the first \`n\` values of the set."""
-    first: Int
-
-    """Only read the last \`n\` values of the set."""
-    last: Int
-
-    """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
-    """The method to use when ordering \`Bar\`."""
-    orderBy: [BarsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): FooBarsByJunctionJFooIdAndJBarIdManyToManyConnection!
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
 }
 
 """A connection to a list of \`Bar\` values, with data from \`Junction\`."""
 type FooBarsByJunctionJFooIdAndJBarIdManyToManyConnection {
-  """A list of \`Bar\` objects."""
-  nodes: [Bar]!
-
   """
   A list of edges which contains the \`Bar\`, info from the \`Junction\`, and the cursor to aid in pagination.
   """
   edges: [FooBarsByJunctionJFooIdAndJBarIdManyToManyEdge!]!
+
+  """A list of \`Bar\` objects."""
+  nodes: [Bar]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -233,11 +228,14 @@ type FooBarsByJunctionJFooIdAndJBarIdManyToManyEdge {
   """A cursor for use in pagination."""
   cursor: Cursor
 
-  """The \`Bar\` at the end of the edge."""
-  node: Bar
-
   """Reads and enables pagination through a set of \`Junction\`."""
   junctionsByJBarId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -245,31 +243,27 @@ type FooBarsByJunctionJFooIdAndJBarIdManyToManyEdge {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
 
     """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection!
+
+  """The \`Bar\` at the end of the edge."""
+  node: Bar
 }
 
 """A connection to a list of \`Foo\` values."""
 type FoosConnection {
-  """A list of \`Foo\` objects."""
-  nodes: [Foo]!
-
   """
   A list of edges which contains the \`Foo\` and cursor to aid in pagination.
   """
   edges: [FoosEdge!]!
+
+  """A list of \`Foo\` objects."""
+  nodes: [Foo]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -289,41 +283,41 @@ type FoosEdge {
 
 """Methods to use when ordering \`Foo\`."""
 enum FoosOrderBy {
-  NATURAL
   FOO_ID_ASC
   FOO_ID_DESC
   FOO_NAME_ASC
   FOO_NAME_DESC
+  NATURAL
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
 
 type Junction implements Node {
-  """
-  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  """
-  nodeId: ID!
-  id: Int!
-  jFooId: Int
-  jBarId: Int
+  """Reads a single \`Bar\` that is related to this \`Junction\`."""
+  barByJBarId: Bar
   createdAt: Datetime!
 
   """Reads a single \`Foo\` that is related to this \`Junction\`."""
   fooByJFooId: Foo
+  id: Int!
+  jBarId: Int
+  jFooId: Int
 
-  """Reads a single \`Bar\` that is related to this \`Junction\`."""
-  barByJBarId: Bar
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
 }
 
 """A connection to a list of \`Junction\` values."""
 type JunctionsConnection {
-  """A list of \`Junction\` objects."""
-  nodes: [Junction]!
-
   """
   A list of edges which contains the \`Junction\` and cursor to aid in pagination.
   """
   edges: [JunctionsEdge!]!
+
+  """A list of \`Junction\` objects."""
+  nodes: [Junction]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -343,15 +337,15 @@ type JunctionsEdge {
 
 """Methods to use when ordering \`Junction\`."""
 enum JunctionsOrderBy {
-  NATURAL
-  ID_ASC
-  ID_DESC
-  J_FOO_ID_ASC
-  J_FOO_ID_DESC
-  J_BAR_ID_ASC
-  J_BAR_ID_DESC
   CREATED_AT_ASC
   CREATED_AT_DESC
+  ID_ASC
+  ID_DESC
+  J_BAR_ID_ASC
+  J_BAR_ID_DESC
+  J_FOO_ID_ASC
+  J_FOO_ID_DESC
+  NATURAL
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
@@ -366,6 +360,9 @@ interface Node {
 
 """Information about pagination in a connection."""
 type PageInfo {
+  """When paginating forwards, the cursor to continue."""
+  endCursor: Cursor
+
   """When paginating forwards, are there more items?"""
   hasNextPage: Boolean!
 
@@ -374,32 +371,18 @@ type PageInfo {
 
   """When paginating backwards, the cursor to continue."""
   startCursor: Cursor
-
-  """When paginating forwards, the cursor to continue."""
-  endCursor: Cursor
 }
 
 """The root query type which gives access points into the data universe."""
 type Query implements Node {
-  """
-  Exposes the root query type nested one level down. This is helpful for Relay 1
-  which can only query top level fields if they are in a particular form.
-  """
-  query: Query!
-
-  """
-  The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
-  """
-  nodeId: ID!
-
-  """Fetches an object given its globally unique \`ID\`."""
-  node(
-    """The globally unique \`ID\`."""
-    nodeId: ID!
-  ): Node
-
   """Reads and enables pagination through a set of \`Bar\`."""
   allBars(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -407,16 +390,9 @@ type Query implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
 
     """The method to use when ordering \`Bar\`."""
     orderBy: [BarsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -424,6 +400,12 @@ type Query implements Node {
 
   """Reads and enables pagination through a set of \`Foo\`."""
   allFoos(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -431,16 +413,9 @@ type Query implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
 
     """The method to use when ordering \`Foo\`."""
     orderBy: [FoosOrderBy!] = [PRIMARY_KEY_ASC]
@@ -448,6 +423,12 @@ type Query implements Node {
 
   """Reads and enables pagination through a set of \`Junction\`."""
   allJunctions(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -455,41 +436,50 @@ type Query implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
 
     """The method to use when ordering \`Junction\`."""
     orderBy: [JunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): JunctionsConnection
-  barByBarId(barId: Int!): Bar
-  fooByFooId(fooId: Int!): Foo
-  junctionById(id: Int!): Junction
 
   """Reads a single \`Bar\` using its globally unique \`ID\`."""
   bar(
     """The globally unique \`ID\` to be used in selecting a single \`Bar\`."""
     nodeId: ID!
   ): Bar
+  barByBarId(barId: Int!): Bar
 
   """Reads a single \`Foo\` using its globally unique \`ID\`."""
   foo(
     """The globally unique \`ID\` to be used in selecting a single \`Foo\`."""
     nodeId: ID!
   ): Foo
+  fooByFooId(fooId: Int!): Foo
 
   """Reads a single \`Junction\` using its globally unique \`ID\`."""
   junction(
     """The globally unique \`ID\` to be used in selecting a single \`Junction\`."""
     nodeId: ID!
   ): Junction
+  junctionById(id: Int!): Junction
+
+  """Fetches an object given its globally unique \`ID\`."""
+  node(
+    """The globally unique \`ID\`."""
+    nodeId: ID!
+  ): Node
+
+  """
+  The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
+  """
+  nodeId: ID!
+
+  """
+  Exposes the root query type nested one level down. This is helpful for Relay 1 which can only query top level fields if they are in a particular form.
+  """
+  query: Query!
 }
 "
 `;

--- a/__tests__/integration/schema/__snapshots__/e.test.js.snap
+++ b/__tests__/integration/schema/__snapshots__/e.test.js.snap
@@ -9,19 +9,18 @@ type Membership implements Node {
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   """
   nodeId: ID!
-  personId: Int!
-  teamId: Int!
 
   """Reads a single \`Person\` that is related to this \`Membership\`."""
   personByPersonId: Person
+  personId: Int!
 
   """Reads a single \`Team\` that is related to this \`Membership\`."""
   teamByTeamId: Team
+  teamId: Int!
 }
 
 """
-A condition to be used against \`Membership\` object types. All fields are tested
-for equality and combined with a logical ‘and.’
+A condition to be used against \`Membership\` object types. All fields are tested for equality and combined with a logical ‘and.’
 """
 input MembershipCondition {
   """Checks for equality with the object’s \`personId\` field."""
@@ -33,13 +32,13 @@ input MembershipCondition {
 
 """A connection to a list of \`Membership\` values."""
 type MembershipsConnection {
-  """A list of \`Membership\` objects."""
-  nodes: [Membership!]!
-
   """
   A list of edges which contains the \`Membership\` and cursor to aid in pagination.
   """
   edges: [MembershipsEdge!]!
+
+  """A list of \`Membership\` objects."""
+  nodes: [Membership!]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -62,10 +61,10 @@ enum MembershipsOrderBy {
   NATURAL
   PERSON_ID_ASC
   PERSON_ID_DESC
-  TEAM_ID_ASC
-  TEAM_ID_DESC
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
+  TEAM_ID_ASC
+  TEAM_ID_DESC
 }
 
 """An object with a globally unique \`ID\`."""
@@ -78,6 +77,9 @@ interface Node {
 
 """Information about pagination in a connection."""
 type PageInfo {
+  """When paginating forwards, the cursor to continue."""
+  endCursor: Cursor
+
   """When paginating forwards, are there more items?"""
   hasNextPage: Boolean!
 
@@ -86,20 +88,17 @@ type PageInfo {
 
   """When paginating backwards, the cursor to continue."""
   startCursor: Cursor
-
-  """When paginating forwards, the cursor to continue."""
-  endCursor: Cursor
 }
 
 """A connection to a list of \`Person\` values."""
 type PeopleConnection {
-  """A list of \`Person\` objects."""
-  nodes: [Person!]!
-
   """
   A list of edges which contains the \`Person\` and cursor to aid in pagination.
   """
   edges: [PeopleEdge!]!
+
+  """A list of \`Person\` objects."""
+  nodes: [Person!]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -119,9 +118,9 @@ type PeopleEdge {
 
 """Methods to use when ordering \`Person\`."""
 enum PeopleOrderBy {
-  NATURAL
   ID_ASC
   ID_DESC
+  NATURAL
   PERSON_NAME_ASC
   PERSON_NAME_DESC
   PRIMARY_KEY_ASC
@@ -129,44 +128,21 @@ enum PeopleOrderBy {
 }
 
 type Person implements Node {
-  """
-  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  """
-  nodeId: ID!
   id: Int!
-  personName: String!
 
   """Reads and enables pagination through a set of \`Membership\`."""
   membershipsByPersonId(
-    """Only read the first \`n\` values of the set."""
-    first: Int
-
-    """Only read the last \`n\` values of the set."""
-    last: Int
-
-    """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
     """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    """The method to use when ordering \`Membership\`."""
-    orderBy: [MembershipsOrderBy!] = [PRIMARY_KEY_ASC]
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
     condition: MembershipCondition
-  ): MembershipsConnection!
 
-  """Reads and enables pagination through a set of \`PersonTagJunction\`."""
-  personTagJunctionsByPersonId(
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -174,28 +150,33 @@ type Person implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
 
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
+    """The method to use when ordering \`Membership\`."""
+    orderBy: [MembershipsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): MembershipsConnection!
 
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  personName: String!
+
+  """Reads and enables pagination through a set of \`PersonTagJunction\`."""
+  personTagJunctionsByPersonId(
     """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    """The method to use when ordering \`PersonTagJunction\`."""
-    orderBy: [PersonTagJunctionsOrderBy!] = [PRIMARY_KEY_ASC]
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
     condition: PersonTagJunctionCondition
-  ): PersonTagJunctionsConnection!
 
-  """Reads and enables pagination through a set of \`Team\`."""
-  teams(
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -203,54 +184,69 @@ type Person implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
 
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
-    """The method to use when ordering \`Team\`."""
-    orderBy: [TeamsOrderBy!] = [PRIMARY_KEY_ASC]
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: TeamCondition
-  ): PersonTeamsManyToManyConnection!
+    """The method to use when ordering \`PersonTagJunction\`."""
+    orderBy: [PersonTagJunctionsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PersonTagJunctionsConnection!
 
   """Reads and enables pagination through a set of \`Tag\`."""
   tags(
-    """Only read the first \`n\` values of the set."""
-    first: Int
-
-    """Only read the last \`n\` values of the set."""
-    last: Int
-
-    """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
     """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    """The method to use when ordering \`Tag\`."""
-    orderBy: [TagsOrderBy!] = [PRIMARY_KEY_ASC]
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
     condition: TagCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Tag\`."""
+    orderBy: [TagsOrderBy!] = [PRIMARY_KEY_ASC]
   ): PersonTagsManyToManyConnection!
+
+  """Reads and enables pagination through a set of \`Team\`."""
+  teams(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: TeamCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Team\`."""
+    orderBy: [TeamsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PersonTeamsManyToManyConnection!
 }
 
 """
@@ -269,19 +265,18 @@ type PersonTagJunction implements Node {
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   """
   nodeId: ID!
-  personId: Int!
-  tagId: Int!
 
   """Reads a single \`Person\` that is related to this \`PersonTagJunction\`."""
   personByPersonId: Person
+  personId: Int!
 
   """Reads a single \`Tag\` that is related to this \`PersonTagJunction\`."""
   tagByTagId: Tag
+  tagId: Int!
 }
 
 """
-A condition to be used against \`PersonTagJunction\` object types. All fields are
-tested for equality and combined with a logical ‘and.’
+A condition to be used against \`PersonTagJunction\` object types. All fields are tested for equality and combined with a logical ‘and.’
 """
 input PersonTagJunctionCondition {
   """Checks for equality with the object’s \`personId\` field."""
@@ -293,13 +288,13 @@ input PersonTagJunctionCondition {
 
 """A connection to a list of \`PersonTagJunction\` values."""
 type PersonTagJunctionsConnection {
-  """A list of \`PersonTagJunction\` objects."""
-  nodes: [PersonTagJunction!]!
-
   """
   A list of edges which contains the \`PersonTagJunction\` and cursor to aid in pagination.
   """
   edges: [PersonTagJunctionsEdge!]!
+
+  """A list of \`PersonTagJunction\` objects."""
+  nodes: [PersonTagJunction!]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -324,23 +319,23 @@ enum PersonTagJunctionsOrderBy {
   NATURAL
   PERSON_ID_ASC
   PERSON_ID_DESC
-  TAG_ID_ASC
-  TAG_ID_DESC
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
+  TAG_ID_ASC
+  TAG_ID_DESC
 }
 
 """
 A connection to a list of \`Tag\` values, with data from \`PersonTagJunction\`.
 """
 type PersonTagsManyToManyConnection {
-  """A list of \`Tag\` objects."""
-  nodes: [Tag!]!
-
   """
   A list of edges which contains the \`Tag\`, info from the \`PersonTagJunction\`, and the cursor to aid in pagination.
   """
   edges: [PersonTagsManyToManyEdge!]!
+
+  """A list of \`Tag\` objects."""
+  nodes: [Tag!]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -360,13 +355,13 @@ type PersonTagsManyToManyEdge {
 
 """A connection to a list of \`Team\` values, with data from \`Membership\`."""
 type PersonTeamsManyToManyConnection {
-  """A list of \`Team\` objects."""
-  nodes: [Team!]!
-
   """
   A list of edges which contains the \`Team\`, info from the \`Membership\`, and the cursor to aid in pagination.
   """
   edges: [PersonTeamsManyToManyEdge!]!
+
+  """A list of \`Team\` objects."""
+  nodes: [Team!]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -386,54 +381,19 @@ type PersonTeamsManyToManyEdge {
 
 """The root query type which gives access points into the data universe."""
 type Query implements Node {
-  """
-  Exposes the root query type nested one level down. This is helpful for Relay 1
-  which can only query top level fields if they are in a particular form.
-  """
-  query: Query!
-
-  """
-  The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
-  """
-  nodeId: ID!
-
-  """Fetches an object given its globally unique \`ID\`."""
-  node(
-    """The globally unique \`ID\`."""
-    nodeId: ID!
-  ): Node
-
   """Reads and enables pagination through a set of \`Membership\`."""
   allMemberships(
-    """Only read the first \`n\` values of the set."""
-    first: Int
-
-    """Only read the last \`n\` values of the set."""
-    last: Int
-
-    """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
     """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    """The method to use when ordering \`Membership\`."""
-    orderBy: [MembershipsOrderBy!] = [PRIMARY_KEY_ASC]
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
     condition: MembershipCondition
-  ): MembershipsConnection
 
-  """Reads and enables pagination through a set of \`Person\`."""
-  allPeople(
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -441,28 +401,27 @@ type Query implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
 
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
+    """The method to use when ordering \`Membership\`."""
+    orderBy: [MembershipsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): MembershipsConnection
 
+  """Reads and enables pagination through a set of \`Person\`."""
+  allPeople(
     """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    """The method to use when ordering \`Person\`."""
-    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
     condition: PersonCondition
-  ): PeopleConnection
 
-  """Reads and enables pagination through a set of \`PersonTagJunction\`."""
-  allPersonTagJunctions(
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -470,28 +429,27 @@ type Query implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
 
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
+    """The method to use when ordering \`Person\`."""
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PeopleConnection
 
+  """Reads and enables pagination through a set of \`PersonTagJunction\`."""
+  allPersonTagJunctions(
     """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    """The method to use when ordering \`PersonTagJunction\`."""
-    orderBy: [PersonTagJunctionsOrderBy!] = [PRIMARY_KEY_ASC]
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
     condition: PersonTagJunctionCondition
-  ): PersonTagJunctionsConnection
 
-  """Reads and enables pagination through a set of \`Tag\`."""
-  allTags(
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -499,28 +457,27 @@ type Query implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
 
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
+    """The method to use when ordering \`PersonTagJunction\`."""
+    orderBy: [PersonTagJunctionsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PersonTagJunctionsConnection
 
+  """Reads and enables pagination through a set of \`Tag\`."""
+  allTags(
     """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    """The method to use when ordering \`Tag\`."""
-    orderBy: [TagsOrderBy!] = [PRIMARY_KEY_ASC]
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
     condition: TagCondition
-  ): TagsConnection
 
-  """Reads and enables pagination through a set of \`Team\`."""
-  allTeams(
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -528,60 +485,69 @@ type Query implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
 
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
-    """The method to use when ordering \`Team\`."""
-    orderBy: [TeamsOrderBy!] = [PRIMARY_KEY_ASC]
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: TeamCondition
-  ): TeamsConnection
+    """The method to use when ordering \`Tag\`."""
+    orderBy: [TagsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): TagsConnection
 
   """Reads and enables pagination through a set of \`TeamTagJunction\`."""
   allTeamTagJunctions(
-    """Only read the first \`n\` values of the set."""
-    first: Int
-
-    """Only read the last \`n\` values of the set."""
-    last: Int
-
-    """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
     """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    """The method to use when ordering \`TeamTagJunction\`."""
-    orderBy: [TeamTagJunctionsOrderBy!] = [PRIMARY_KEY_ASC]
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
     condition: TeamTagJunctionCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`TeamTagJunction\`."""
+    orderBy: [TeamTagJunctionsOrderBy!] = [PRIMARY_KEY_ASC]
   ): TeamTagJunctionsConnection
-  membershipByPersonIdAndTeamId(personId: Int!, teamId: Int!): Membership
-  personById(id: Int!): Person
-  personTagJunctionByPersonIdAndTagId(personId: Int!, tagId: Int!): PersonTagJunction
-  tagById(id: Int!): Tag
-  teamById(id: Int!): Team
-  teamTagJunctionByTeamIdAndTagId(teamId: Int!, tagId: Int!): TeamTagJunction
+
+  """Reads and enables pagination through a set of \`Team\`."""
+  allTeams(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: TeamCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Team\`."""
+    orderBy: [TeamsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): TeamsConnection
 
   """Reads a single \`Membership\` using its globally unique \`ID\`."""
   membership(
@@ -590,12 +556,25 @@ type Query implements Node {
     """
     nodeId: ID!
   ): Membership
+  membershipByPersonIdAndTeamId(personId: Int!, teamId: Int!): Membership
+
+  """Fetches an object given its globally unique \`ID\`."""
+  node(
+    """The globally unique \`ID\`."""
+    nodeId: ID!
+  ): Node
+
+  """
+  The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
+  """
+  nodeId: ID!
 
   """Reads a single \`Person\` using its globally unique \`ID\`."""
   person(
     """The globally unique \`ID\` to be used in selecting a single \`Person\`."""
     nodeId: ID!
   ): Person
+  personById(id: Int!): Person
 
   """Reads a single \`PersonTagJunction\` using its globally unique \`ID\`."""
   personTagJunction(
@@ -604,18 +583,26 @@ type Query implements Node {
     """
     nodeId: ID!
   ): PersonTagJunction
+  personTagJunctionByPersonIdAndTagId(personId: Int!, tagId: Int!): PersonTagJunction
+
+  """
+  Exposes the root query type nested one level down. This is helpful for Relay 1 which can only query top level fields if they are in a particular form.
+  """
+  query: Query!
 
   """Reads a single \`Tag\` using its globally unique \`ID\`."""
   tag(
     """The globally unique \`ID\` to be used in selecting a single \`Tag\`."""
     nodeId: ID!
   ): Tag
+  tagById(id: Int!): Tag
 
   """Reads a single \`Team\` using its globally unique \`ID\`."""
   team(
     """The globally unique \`ID\` to be used in selecting a single \`Team\`."""
     nodeId: ID!
   ): Team
+  teamById(id: Int!): Team
 
   """Reads a single \`TeamTagJunction\` using its globally unique \`ID\`."""
   teamTagJunction(
@@ -624,105 +611,30 @@ type Query implements Node {
     """
     nodeId: ID!
   ): TeamTagJunction
+  teamTagJunctionByTeamIdAndTagId(tagId: Int!, teamId: Int!): TeamTagJunction
 }
 
 type Tag implements Node {
+  id: Int!
+
   """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   """
   nodeId: ID!
-  id: Int!
-  tagName: String!
-
-  """Reads and enables pagination through a set of \`PersonTagJunction\`."""
-  personTagJunctionsByTagId(
-    """Only read the first \`n\` values of the set."""
-    first: Int
-
-    """Only read the last \`n\` values of the set."""
-    last: Int
-
-    """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
-    """The method to use when ordering \`PersonTagJunction\`."""
-    orderBy: [PersonTagJunctionsOrderBy!] = [PRIMARY_KEY_ASC]
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: PersonTagJunctionCondition
-  ): PersonTagJunctionsConnection!
-
-  """Reads and enables pagination through a set of \`TeamTagJunction\`."""
-  teamTagJunctionsByTagId(
-    """Only read the first \`n\` values of the set."""
-    first: Int
-
-    """Only read the last \`n\` values of the set."""
-    last: Int
-
-    """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
-    """The method to use when ordering \`TeamTagJunction\`."""
-    orderBy: [TeamTagJunctionsOrderBy!] = [PRIMARY_KEY_ASC]
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: TeamTagJunctionCondition
-  ): TeamTagJunctionsConnection!
 
   """Reads and enables pagination through a set of \`Person\`."""
   people(
-    """Only read the first \`n\` values of the set."""
-    first: Int
-
-    """Only read the last \`n\` values of the set."""
-    last: Int
-
-    """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
     """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    """The method to use when ordering \`Person\`."""
-    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
     condition: PersonCondition
-  ): TagPeopleManyToManyConnection!
 
-  """Reads and enables pagination through a set of \`Team\`."""
-  teams(
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -730,24 +642,97 @@ type Tag implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
+
+    """The method to use when ordering \`Person\`."""
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+  ): TagPeopleManyToManyConnection!
+
+  """Reads and enables pagination through a set of \`PersonTagJunction\`."""
+  personTagJunctionsByTagId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
 
     """Read all values in the set before (above) this cursor."""
     before: Cursor
 
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonTagJunctionCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`PersonTagJunction\`."""
+    orderBy: [PersonTagJunctionsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PersonTagJunctionsConnection!
+  tagName: String!
+
+  """Reads and enables pagination through a set of \`TeamTagJunction\`."""
+  teamTagJunctionsByTagId(
     """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    """The method to use when ordering \`Team\`."""
-    orderBy: [TeamsOrderBy!] = [PRIMARY_KEY_ASC]
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: TeamTagJunctionCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`TeamTagJunction\`."""
+    orderBy: [TeamTagJunctionsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): TeamTagJunctionsConnection!
+
+  """Reads and enables pagination through a set of \`Team\`."""
+  teams(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
     condition: TeamCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Team\`."""
+    orderBy: [TeamsOrderBy!] = [PRIMARY_KEY_ASC]
   ): TagTeamsManyToManyConnection!
 }
 
@@ -766,13 +751,13 @@ input TagCondition {
 A connection to a list of \`Person\` values, with data from \`PersonTagJunction\`.
 """
 type TagPeopleManyToManyConnection {
-  """A list of \`Person\` objects."""
-  nodes: [Person!]!
-
   """
   A list of edges which contains the \`Person\`, info from the \`PersonTagJunction\`, and the cursor to aid in pagination.
   """
   edges: [TagPeopleManyToManyEdge!]!
+
+  """A list of \`Person\` objects."""
+  nodes: [Person!]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -790,15 +775,43 @@ type TagPeopleManyToManyEdge {
   node: Person!
 }
 
+"""
+A connection to a list of \`Team\` values, with data from \`TeamTagJunction\`.
+"""
+type TagTeamsManyToManyConnection {
+  """
+  A list of edges which contains the \`Team\`, info from the \`TeamTagJunction\`, and the cursor to aid in pagination.
+  """
+  edges: [TagTeamsManyToManyEdge!]!
+
+  """A list of \`Team\` objects."""
+  nodes: [Team!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`Team\` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A \`Team\` edge in the connection, with data from \`TeamTagJunction\`."""
+type TagTeamsManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`Team\` at the end of the edge."""
+  node: Team!
+}
+
 """A connection to a list of \`Tag\` values."""
 type TagsConnection {
-  """A list of \`Tag\` objects."""
-  nodes: [Tag!]!
-
   """
   A list of edges which contains the \`Tag\` and cursor to aid in pagination.
   """
   edges: [TagsEdge!]!
+
+  """A list of \`Tag\` objects."""
+  nodes: [Tag!]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -818,82 +831,31 @@ type TagsEdge {
 
 """Methods to use when ordering \`Tag\`."""
 enum TagsOrderBy {
-  NATURAL
   ID_ASC
   ID_DESC
-  TAG_NAME_ASC
-  TAG_NAME_DESC
+  NATURAL
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
-}
-
-"""
-A connection to a list of \`Team\` values, with data from \`TeamTagJunction\`.
-"""
-type TagTeamsManyToManyConnection {
-  """A list of \`Team\` objects."""
-  nodes: [Team!]!
-
-  """
-  A list of edges which contains the \`Team\`, info from the \`TeamTagJunction\`, and the cursor to aid in pagination.
-  """
-  edges: [TagTeamsManyToManyEdge!]!
-
-  """Information to aid in pagination."""
-  pageInfo: PageInfo!
-
-  """The count of *all* \`Team\` you could get from the connection."""
-  totalCount: Int!
-}
-
-"""A \`Team\` edge in the connection, with data from \`TeamTagJunction\`."""
-type TagTeamsManyToManyEdge {
-  """A cursor for use in pagination."""
-  cursor: Cursor
-
-  """The \`Team\` at the end of the edge."""
-  node: Team!
+  TAG_NAME_ASC
+  TAG_NAME_DESC
 }
 
 type Team implements Node {
-  """
-  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  """
-  nodeId: ID!
   id: Int!
-  teamName: String!
 
   """Reads and enables pagination through a set of \`Membership\`."""
   membershipsByTeamId(
-    """Only read the first \`n\` values of the set."""
-    first: Int
-
-    """Only read the last \`n\` values of the set."""
-    last: Int
-
-    """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
     """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    """The method to use when ordering \`Membership\`."""
-    orderBy: [MembershipsOrderBy!] = [PRIMARY_KEY_ASC]
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
     condition: MembershipCondition
-  ): MembershipsConnection!
 
-  """Reads and enables pagination through a set of \`TeamTagJunction\`."""
-  teamTagJunctionsByTeamId(
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -901,57 +863,32 @@ type Team implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
 
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
+    """The method to use when ordering \`Membership\`."""
+    orderBy: [MembershipsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): MembershipsConnection!
 
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
-    """The method to use when ordering \`TeamTagJunction\`."""
-    orderBy: [TeamTagJunctionsOrderBy!] = [PRIMARY_KEY_ASC]
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: TeamTagJunctionCondition
-  ): TeamTagJunctionsConnection!
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
 
   """Reads and enables pagination through a set of \`Person\`."""
   people(
-    """Only read the first \`n\` values of the set."""
-    first: Int
-
-    """Only read the last \`n\` values of the set."""
-    last: Int
-
-    """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
     """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    """The method to use when ordering \`Person\`."""
-    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
     condition: PersonCondition
-  ): TeamPeopleManyToManyConnection!
 
-  """Reads and enables pagination through a set of \`Tag\`."""
-  tags(
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -959,25 +896,70 @@ type Team implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
 
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
+    """The method to use when ordering \`Person\`."""
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+  ): TeamPeopleManyToManyConnection!
 
+  """Reads and enables pagination through a set of \`Tag\`."""
+  tags(
     """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    """The method to use when ordering \`Tag\`."""
-    orderBy: [TagsOrderBy!] = [PRIMARY_KEY_ASC]
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
     condition: TagCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Tag\`."""
+    orderBy: [TagsOrderBy!] = [PRIMARY_KEY_ASC]
   ): TeamTagsManyToManyConnection!
+  teamName: String!
+
+  """Reads and enables pagination through a set of \`TeamTagJunction\`."""
+  teamTagJunctionsByTeamId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: TeamTagJunctionCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`TeamTagJunction\`."""
+    orderBy: [TeamTagJunctionsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): TeamTagJunctionsConnection!
 }
 
 """
@@ -995,13 +977,13 @@ input TeamCondition {
 A connection to a list of \`Person\` values, with data from \`Membership\`.
 """
 type TeamPeopleManyToManyConnection {
-  """A list of \`Person\` objects."""
-  nodes: [Person!]!
-
   """
   A list of edges which contains the \`Person\`, info from the \`Membership\`, and the cursor to aid in pagination.
   """
   edges: [TeamPeopleManyToManyEdge!]!
+
+  """A list of \`Person\` objects."""
+  nodes: [Person!]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -1019,79 +1001,41 @@ type TeamPeopleManyToManyEdge {
   node: Person!
 }
 
-"""A connection to a list of \`Team\` values."""
-type TeamsConnection {
-  """A list of \`Team\` objects."""
-  nodes: [Team!]!
-
-  """
-  A list of edges which contains the \`Team\` and cursor to aid in pagination.
-  """
-  edges: [TeamsEdge!]!
-
-  """Information to aid in pagination."""
-  pageInfo: PageInfo!
-
-  """The count of *all* \`Team\` you could get from the connection."""
-  totalCount: Int!
-}
-
-"""A \`Team\` edge in the connection."""
-type TeamsEdge {
-  """A cursor for use in pagination."""
-  cursor: Cursor
-
-  """The \`Team\` at the end of the edge."""
-  node: Team!
-}
-
-"""Methods to use when ordering \`Team\`."""
-enum TeamsOrderBy {
-  NATURAL
-  ID_ASC
-  ID_DESC
-  TEAM_NAME_ASC
-  TEAM_NAME_DESC
-  PRIMARY_KEY_ASC
-  PRIMARY_KEY_DESC
-}
-
 type TeamTagJunction implements Node {
   """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   """
   nodeId: ID!
-  teamId: Int!
+
+  """Reads a single \`Tag\` that is related to this \`TeamTagJunction\`."""
+  tagByTagId: Tag
   tagId: Int!
 
   """Reads a single \`Team\` that is related to this \`TeamTagJunction\`."""
   teamByTeamId: Team
-
-  """Reads a single \`Tag\` that is related to this \`TeamTagJunction\`."""
-  tagByTagId: Tag
+  teamId: Int!
 }
 
 """
-A condition to be used against \`TeamTagJunction\` object types. All fields are
-tested for equality and combined with a logical ‘and.’
+A condition to be used against \`TeamTagJunction\` object types. All fields are tested for equality and combined with a logical ‘and.’
 """
 input TeamTagJunctionCondition {
-  """Checks for equality with the object’s \`teamId\` field."""
-  teamId: Int
-
   """Checks for equality with the object’s \`tagId\` field."""
   tagId: Int
+
+  """Checks for equality with the object’s \`teamId\` field."""
+  teamId: Int
 }
 
 """A connection to a list of \`TeamTagJunction\` values."""
 type TeamTagJunctionsConnection {
-  """A list of \`TeamTagJunction\` objects."""
-  nodes: [TeamTagJunction!]!
-
   """
   A list of edges which contains the \`TeamTagJunction\` and cursor to aid in pagination.
   """
   edges: [TeamTagJunctionsEdge!]!
+
+  """A list of \`TeamTagJunction\` objects."""
+  nodes: [TeamTagJunction!]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -1114,25 +1058,25 @@ type TeamTagJunctionsEdge {
 """Methods to use when ordering \`TeamTagJunction\`."""
 enum TeamTagJunctionsOrderBy {
   NATURAL
-  TEAM_ID_ASC
-  TEAM_ID_DESC
-  TAG_ID_ASC
-  TAG_ID_DESC
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
+  TAG_ID_ASC
+  TAG_ID_DESC
+  TEAM_ID_ASC
+  TEAM_ID_DESC
 }
 
 """
 A connection to a list of \`Tag\` values, with data from \`TeamTagJunction\`.
 """
 type TeamTagsManyToManyConnection {
-  """A list of \`Tag\` objects."""
-  nodes: [Tag!]!
-
   """
   A list of edges which contains the \`Tag\`, info from the \`TeamTagJunction\`, and the cursor to aid in pagination.
   """
   edges: [TeamTagsManyToManyEdge!]!
+
+  """A list of \`Tag\` objects."""
+  nodes: [Tag!]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -1148,6 +1092,43 @@ type TeamTagsManyToManyEdge {
 
   """The \`Tag\` at the end of the edge."""
   node: Tag!
+}
+
+"""A connection to a list of \`Team\` values."""
+type TeamsConnection {
+  """
+  A list of edges which contains the \`Team\` and cursor to aid in pagination.
+  """
+  edges: [TeamsEdge!]!
+
+  """A list of \`Team\` objects."""
+  nodes: [Team!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`Team\` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A \`Team\` edge in the connection."""
+type TeamsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`Team\` at the end of the edge."""
+  node: Team!
+}
+
+"""Methods to use when ordering \`Team\`."""
+enum TeamsOrderBy {
+  ID_ASC
+  ID_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  TEAM_NAME_ASC
+  TEAM_NAME_DESC
 }
 "
 `;

--- a/__tests__/integration/schema/__snapshots__/f.test.js.snap
+++ b/__tests__/integration/schema/__snapshots__/f.test.js.snap
@@ -5,12 +5,13 @@ exports[`prints a schema with the many-to-many plugin 1`] = `
 scalar Cursor
 
 type Junction implements Node {
+  followerId: Int!
+  followingId: Int!
+
   """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   """
   nodeId: ID!
-  followerId: Int!
-  followingId: Int!
 
   """Reads a single \`Person\` that is related to this \`Junction\`."""
   personByFollowerId: Person
@@ -29,6 +30,9 @@ interface Node {
 
 """Information about pagination in a connection."""
 type PageInfo {
+  """When paginating forwards, the cursor to continue."""
+  endCursor: Cursor
+
   """When paginating forwards, are there more items?"""
   hasNextPage: Boolean!
 
@@ -37,20 +41,17 @@ type PageInfo {
 
   """When paginating backwards, the cursor to continue."""
   startCursor: Cursor
-
-  """When paginating forwards, the cursor to continue."""
-  endCursor: Cursor
 }
 
 """A connection to a list of \`Person\` values."""
 type PeopleConnection {
-  """A list of \`Person\` objects."""
-  nodes: [Person]!
-
   """
   A list of edges which contains the \`Person\` and cursor to aid in pagination.
   """
   edges: [PeopleEdge!]!
+
+  """A list of \`Person\` objects."""
+  nodes: [Person]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -70,80 +71,78 @@ type PeopleEdge {
 
 """Methods to use when ordering \`Person\`."""
 enum PeopleOrderBy {
-  NATURAL
   ID_ASC
   ID_DESC
   NAME_ASC
   NAME_DESC
+  NATURAL
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
 
 type Person implements Node {
+  """Reads and enables pagination through a set of \`Person\`."""
+  followers(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Person\`."""
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PersonFollowersManyToManyConnection!
+
+  """Reads and enables pagination through a set of \`Person\`."""
+  following(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Person\`."""
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PersonFollowingManyToManyConnection!
+  id: Int!
+  name: String
+
   """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   """
   nodeId: ID!
-  id: Int!
-  name: String
-
-  """Reads and enables pagination through a set of \`Person\`."""
-  following(
-    """Only read the first \`n\` values of the set."""
-    first: Int
-
-    """Only read the last \`n\` values of the set."""
-    last: Int
-
-    """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
-    """The method to use when ordering \`Person\`."""
-    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: PersonCondition
-  ): PersonFollowingManyToManyConnection!
-
-  """Reads and enables pagination through a set of \`Person\`."""
-  followers(
-    """Only read the first \`n\` values of the set."""
-    first: Int
-
-    """Only read the last \`n\` values of the set."""
-    last: Int
-
-    """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
-    """The method to use when ordering \`Person\`."""
-    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: PersonCondition
-  ): PersonFollowersManyToManyConnection!
 }
 
 """
@@ -159,13 +158,13 @@ input PersonCondition {
 
 """A connection to a list of \`Person\` values, with data from \`Junction\`."""
 type PersonFollowersManyToManyConnection {
-  """A list of \`Person\` objects."""
-  nodes: [Person]!
-
   """
   A list of edges which contains the \`Person\`, info from the \`Junction\`, and the cursor to aid in pagination.
   """
   edges: [PersonFollowersManyToManyEdge!]!
+
+  """A list of \`Person\` objects."""
+  nodes: [Person]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -185,13 +184,13 @@ type PersonFollowersManyToManyEdge {
 
 """A connection to a list of \`Person\` values, with data from \`Junction\`."""
 type PersonFollowingManyToManyConnection {
-  """A list of \`Person\` objects."""
-  nodes: [Person]!
-
   """
   A list of edges which contains the \`Person\`, info from the \`Junction\`, and the cursor to aid in pagination.
   """
   edges: [PersonFollowingManyToManyEdge!]!
+
+  """A list of \`Person\` objects."""
+  nodes: [Person]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -211,25 +210,19 @@ type PersonFollowingManyToManyEdge {
 
 """The root query type which gives access points into the data universe."""
 type Query implements Node {
-  """
-  Exposes the root query type nested one level down. This is helpful for Relay 1
-  which can only query top level fields if they are in a particular form.
-  """
-  query: Query!
-
-  """
-  The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
-  """
-  nodeId: ID!
-
-  """Fetches an object given its globally unique \`ID\`."""
-  node(
-    """The globally unique \`ID\`."""
-    nodeId: ID!
-  ): Node
-
   """Reads and enables pagination through a set of \`Person\`."""
   allPeople(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -237,39 +230,43 @@ type Query implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
 
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
     """The method to use when ordering \`Person\`."""
     orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: PersonCondition
   ): PeopleConnection
-  junctionByFollowerIdAndFollowingId(followerId: Int!, followingId: Int!): Junction
-  personById(id: Int!): Person
 
   """Reads a single \`Junction\` using its globally unique \`ID\`."""
   junction(
     """The globally unique \`ID\` to be used in selecting a single \`Junction\`."""
     nodeId: ID!
   ): Junction
+  junctionByFollowerIdAndFollowingId(followerId: Int!, followingId: Int!): Junction
+
+  """Fetches an object given its globally unique \`ID\`."""
+  node(
+    """The globally unique \`ID\`."""
+    nodeId: ID!
+  ): Node
+
+  """
+  The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
+  """
+  nodeId: ID!
 
   """Reads a single \`Person\` using its globally unique \`ID\`."""
   person(
     """The globally unique \`ID\` to be used in selecting a single \`Person\`."""
     nodeId: ID!
   ): Person
+  personById(id: Int!): Person
+
+  """
+  Exposes the root query type nested one level down. This is helpful for Relay 1 which can only query top level fields if they are in a particular form.
+  """
+  query: Query!
 }
 "
 `;

--- a/__tests__/integration/schema/__snapshots__/g.test.js.snap
+++ b/__tests__/integration/schema/__snapshots__/g.test.js.snap
@@ -5,8 +5,7 @@ exports[`prints a schema with the many-to-many plugin 1`] = `
 scalar Cursor
 
 """
-A point in time as described by the [ISO
-8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
+A point in time as described by the [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
 """
 scalar Datetime
 
@@ -20,6 +19,9 @@ interface Node {
 
 """Information about pagination in a connection."""
 type PageInfo {
+  """When paginating forwards, the cursor to continue."""
+  endCursor: Cursor
+
   """When paginating forwards, are there more items?"""
   hasNextPage: Boolean!
 
@@ -28,23 +30,22 @@ type PageInfo {
 
   """When paginating backwards, the cursor to continue."""
   startCursor: Cursor
-
-  """When paginating forwards, the cursor to continue."""
-  endCursor: Cursor
 }
 
 type Post implements Node {
-  """
-  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  """
-  nodeId: ID!
-  id: UUID!
-  title: String!
-  content: String
-  createdAt: Datetime!
-
   """Reads and enables pagination through a set of \`User\`."""
   authors(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: UserCondition
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -52,49 +53,49 @@ type Post implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
 
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
     """The method to use when ordering \`User\`."""
     orderBy: [UsersOrderBy!] = [PRIMARY_KEY_ASC]
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: UserCondition
   ): PostAuthorsManyToManyConnection!
-}
+  content: String
+  createdAt: Datetime!
+  id: UUID!
 
-type PostAuthor implements Node {
   """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   """
   nodeId: ID!
-  id: UUID!
-  postId: UUID!
-  userId: UUID!
+  title: String!
+}
+
+type PostAuthor implements Node {
   createdAt: Datetime!
+  id: UUID!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
 
   """Reads a single \`Post\` that is related to this \`PostAuthor\`."""
   postByPostId: Post
+  postId: UUID!
 
   """Reads a single \`User\` that is related to this \`PostAuthor\`."""
   userByUserId: User
+  userId: UUID!
 }
 
 """
-A condition to be used against \`PostAuthor\` object types. All fields are tested
-for equality and combined with a logical ‘and.’
+A condition to be used against \`PostAuthor\` object types. All fields are tested for equality and combined with a logical ‘and.’
 """
 input PostAuthorCondition {
+  """Checks for equality with the object’s \`createdAt\` field."""
+  createdAt: Datetime
+
   """Checks for equality with the object’s \`id\` field."""
   id: UUID
 
@@ -103,20 +104,17 @@ input PostAuthorCondition {
 
   """Checks for equality with the object’s \`userId\` field."""
   userId: UUID
-
-  """Checks for equality with the object’s \`createdAt\` field."""
-  createdAt: Datetime
 }
 
 """A connection to a list of \`PostAuthor\` values."""
 type PostAuthorsConnection {
-  """A list of \`PostAuthor\` objects."""
-  nodes: [PostAuthor]!
-
   """
   A list of edges which contains the \`PostAuthor\` and cursor to aid in pagination.
   """
   edges: [PostAuthorsEdge!]!
+
+  """A list of \`PostAuthor\` objects."""
+  nodes: [PostAuthor]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -136,13 +134,13 @@ type PostAuthorsEdge {
 
 """A connection to a list of \`User\` values, with data from \`PostAuthor\`."""
 type PostAuthorsManyToManyConnection {
-  """A list of \`User\` objects."""
-  nodes: [User]!
-
   """
   A list of edges which contains the \`User\`, info from the \`PostAuthor\`, and the cursor to aid in pagination.
   """
   edges: [PostAuthorsManyToManyEdge!]!
+
+  """A list of \`User\` objects."""
+  nodes: [User]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -161,6 +159,17 @@ type PostAuthorsManyToManyEdge {
 
   """Reads and enables pagination through a set of \`PostAuthor\`."""
   postAuthorsByUserId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PostAuthorCondition
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -168,68 +177,56 @@ type PostAuthorsManyToManyEdge {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
 
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
     """The method to use when ordering \`PostAuthor\`."""
     orderBy: [PostAuthorsOrderBy!] = [PRIMARY_KEY_ASC]
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: PostAuthorCondition
   ): PostAuthorsConnection!
 }
 
 """Methods to use when ordering \`PostAuthor\`."""
 enum PostAuthorsOrderBy {
-  NATURAL
-  ID_ASC
-  ID_DESC
-  POST_ID_ASC
-  POST_ID_DESC
-  USER_ID_ASC
-  USER_ID_DESC
   CREATED_AT_ASC
   CREATED_AT_DESC
+  ID_ASC
+  ID_DESC
+  NATURAL
+  POST_ID_ASC
+  POST_ID_DESC
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
+  USER_ID_ASC
+  USER_ID_DESC
 }
 
 """
 A condition to be used against \`Post\` object types. All fields are tested for equality and combined with a logical ‘and.’
 """
 input PostCondition {
-  """Checks for equality with the object’s \`id\` field."""
-  id: UUID
-
-  """Checks for equality with the object’s \`title\` field."""
-  title: String
-
   """Checks for equality with the object’s \`content\` field."""
   content: String
 
   """Checks for equality with the object’s \`createdAt\` field."""
   createdAt: Datetime
+
+  """Checks for equality with the object’s \`id\` field."""
+  id: UUID
+
+  """Checks for equality with the object’s \`title\` field."""
+  title: String
 }
 
 """A connection to a list of \`Post\` values."""
 type PostsConnection {
-  """A list of \`Post\` objects."""
-  nodes: [Post]!
-
   """
   A list of edges which contains the \`Post\` and cursor to aid in pagination.
   """
   edges: [PostsEdge!]!
+
+  """A list of \`Post\` objects."""
+  nodes: [Post]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -249,31 +246,104 @@ type PostsEdge {
 
 """Methods to use when ordering \`Post\`."""
 enum PostsOrderBy {
-  NATURAL
-  ID_ASC
-  ID_DESC
-  TITLE_ASC
-  TITLE_DESC
   CONTENT_ASC
   CONTENT_DESC
   CREATED_AT_ASC
   CREATED_AT_DESC
+  ID_ASC
+  ID_DESC
+  NATURAL
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
+  TITLE_ASC
+  TITLE_DESC
 }
 
 """The root query type which gives access points into the data universe."""
 type Query implements Node {
-  """
-  Exposes the root query type nested one level down. This is helpful for Relay 1
-  which can only query top level fields if they are in a particular form.
-  """
-  query: Query!
+  """Reads and enables pagination through a set of \`PostAuthor\`."""
+  allPostAuthors(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
 
-  """
-  The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
-  """
-  nodeId: ID!
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PostAuthorCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`PostAuthor\`."""
+    orderBy: [PostAuthorsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PostAuthorsConnection
+
+  """Reads and enables pagination through a set of \`Post\`."""
+  allPosts(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PostCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Post\`."""
+    orderBy: [PostsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PostsConnection
+
+  """Reads and enables pagination through a set of \`User\`."""
+  allUsers(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: UserCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`User\`."""
+    orderBy: [UsersOrderBy!] = [PRIMARY_KEY_ASC]
+  ): UsersConnection
 
   """Fetches an object given its globally unique \`ID\`."""
   node(
@@ -281,95 +351,16 @@ type Query implements Node {
     nodeId: ID!
   ): Node
 
-  """Reads and enables pagination through a set of \`PostAuthor\`."""
-  allPostAuthors(
-    """Only read the first \`n\` values of the set."""
-    first: Int
+  """
+  The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
+  """
+  nodeId: ID!
 
-    """Only read the last \`n\` values of the set."""
-    last: Int
-
-    """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
-    """The method to use when ordering \`PostAuthor\`."""
-    orderBy: [PostAuthorsOrderBy!] = [PRIMARY_KEY_ASC]
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: PostAuthorCondition
-  ): PostAuthorsConnection
-
-  """Reads and enables pagination through a set of \`Post\`."""
-  allPosts(
-    """Only read the first \`n\` values of the set."""
-    first: Int
-
-    """Only read the last \`n\` values of the set."""
-    last: Int
-
-    """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
-    """The method to use when ordering \`Post\`."""
-    orderBy: [PostsOrderBy!] = [PRIMARY_KEY_ASC]
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: PostCondition
-  ): PostsConnection
-
-  """Reads and enables pagination through a set of \`User\`."""
-  allUsers(
-    """Only read the first \`n\` values of the set."""
-    first: Int
-
-    """Only read the last \`n\` values of the set."""
-    last: Int
-
-    """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
-    """The method to use when ordering \`User\`."""
-    orderBy: [UsersOrderBy!] = [PRIMARY_KEY_ASC]
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: UserCondition
-  ): UsersConnection
-  postAuthorById(id: UUID!): PostAuthor
-  postById(id: UUID!): Post
-  userById(id: UUID!): User
+  """Reads a single \`Post\` using its globally unique \`ID\`."""
+  post(
+    """The globally unique \`ID\` to be used in selecting a single \`Post\`."""
+    nodeId: ID!
+  ): Post
 
   """Reads a single \`PostAuthor\` using its globally unique \`ID\`."""
   postAuthor(
@@ -378,29 +369,48 @@ type Query implements Node {
     """
     nodeId: ID!
   ): PostAuthor
+  postAuthorById(id: UUID!): PostAuthor
+  postById(id: UUID!): Post
 
-  """Reads a single \`Post\` using its globally unique \`ID\`."""
-  post(
-    """The globally unique \`ID\` to be used in selecting a single \`Post\`."""
-    nodeId: ID!
-  ): Post
+  """
+  Exposes the root query type nested one level down. This is helpful for Relay 1 which can only query top level fields if they are in a particular form.
+  """
+  query: Query!
 
   """Reads a single \`User\` using its globally unique \`ID\`."""
   user(
     """The globally unique \`ID\` to be used in selecting a single \`User\`."""
     nodeId: ID!
   ): User
+  userById(id: UUID!): User
 }
 
+"""
+A universally unique identifier as defined by [RFC 4122](https://tools.ietf.org/html/rfc4122).
+"""
+scalar UUID
+
 type User implements Node {
+  id: UUID!
+
   """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   """
   nodeId: ID!
-  id: UUID!
 
   """Reads and enables pagination through a set of \`Post\`."""
   postsByPostAuthorUserIdAndPostId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PostCondition
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -408,24 +418,12 @@ type User implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
 
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
     """The method to use when ordering \`Post\`."""
     orderBy: [PostsOrderBy!] = [PRIMARY_KEY_ASC]
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: PostCondition
   ): UserPostsByPostAuthorUserIdAndPostIdManyToManyConnection!
 }
 
@@ -439,13 +437,13 @@ input UserCondition {
 
 """A connection to a list of \`Post\` values, with data from \`PostAuthor\`."""
 type UserPostsByPostAuthorUserIdAndPostIdManyToManyConnection {
-  """A list of \`Post\` objects."""
-  nodes: [Post]!
-
   """
   A list of edges which contains the \`Post\`, info from the \`PostAuthor\`, and the cursor to aid in pagination.
   """
   edges: [UserPostsByPostAuthorUserIdAndPostIdManyToManyEdge!]!
+
+  """A list of \`Post\` objects."""
+  nodes: [Post]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -464,6 +462,17 @@ type UserPostsByPostAuthorUserIdAndPostIdManyToManyEdge {
 
   """Reads and enables pagination through a set of \`PostAuthor\`."""
   postAuthorsByPostId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PostAuthorCondition
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -471,36 +480,24 @@ type UserPostsByPostAuthorUserIdAndPostIdManyToManyEdge {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
 
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
     """The method to use when ordering \`PostAuthor\`."""
     orderBy: [PostAuthorsOrderBy!] = [PRIMARY_KEY_ASC]
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: PostAuthorCondition
   ): PostAuthorsConnection!
 }
 
 """A connection to a list of \`User\` values."""
 type UsersConnection {
-  """A list of \`User\` objects."""
-  nodes: [User]!
-
   """
   A list of edges which contains the \`User\` and cursor to aid in pagination.
   """
   edges: [UsersEdge!]!
+
+  """A list of \`User\` objects."""
+  nodes: [User]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -520,16 +517,11 @@ type UsersEdge {
 
 """Methods to use when ordering \`User\`."""
 enum UsersOrderBy {
-  NATURAL
   ID_ASC
   ID_DESC
+  NATURAL
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
-
-"""
-A universally unique identifier as defined by [RFC 4122](https://tools.ietf.org/html/rfc4122).
-"""
-scalar UUID
 "
 `;

--- a/__tests__/integration/schema/__snapshots__/p.ignoreIndexesFalse.test.js.snap
+++ b/__tests__/integration/schema/__snapshots__/p.ignoreIndexesFalse.test.js.snap
@@ -2,12 +2,13 @@
 
 exports[`prints a schema with \`ignoreIndexes: false\` 1`] = `
 "type Bar implements Node {
+  id: Int!
+  name: String!
+
   """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   """
   nodeId: ID!
-  id: Int!
-  name: String!
 }
 
 """
@@ -20,13 +21,13 @@ input BarCondition {
 
 """A connection to a list of \`Bar\` values."""
 type BarsConnection {
-  """A list of \`Bar\` objects."""
-  nodes: [Bar]!
-
   """
   A list of edges which contains the \`Bar\` and cursor to aid in pagination.
   """
   edges: [BarsEdge!]!
+
+  """A list of \`Bar\` objects."""
+  nodes: [Bar]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -46,23 +47,24 @@ type BarsEdge {
 
 """Methods to use when ordering \`Bar\`."""
 enum BarsOrderBy {
-  NATURAL
   ID_ASC
   ID_DESC
+  NATURAL
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
 
 type Baz implements Node {
-  """
-  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  """
-  nodeId: ID!
-  fooId: Int!
   barId: Int!
 
   """Reads a single \`Foo\` that is related to this \`Baz\`."""
   fooByFooId: Foo
+  fooId: Int!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
 }
 
 """
@@ -75,13 +77,13 @@ input BazCondition {
 
 """A connection to a list of \`Baz\` values."""
 type BazsConnection {
-  """A list of \`Baz\` objects."""
-  nodes: [Baz]!
-
   """
   A list of edges which contains the \`Baz\` and cursor to aid in pagination.
   """
   edges: [BazsEdge!]!
+
+  """A list of \`Baz\` objects."""
+  nodes: [Baz]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -101,23 +103,24 @@ type BazsEdge {
 
 """Methods to use when ordering \`Baz\`."""
 enum BazsOrderBy {
-  NATURAL
   FOO_ID_ASC
   FOO_ID_DESC
+  NATURAL
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
 
 type Corge implements Node {
-  """
-  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  """
-  nodeId: ID!
-  fooId: Int!
   barId: Int!
 
   """Reads a single \`Foo\` that is related to this \`Corge\`."""
   fooByFooId: Foo
+  fooId: Int!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
 }
 
 """
@@ -130,13 +133,13 @@ input CorgeCondition {
 
 """A connection to a list of \`Corge\` values."""
 type CorgesConnection {
-  """A list of \`Corge\` objects."""
-  nodes: [Corge]!
-
   """
   A list of edges which contains the \`Corge\` and cursor to aid in pagination.
   """
   edges: [CorgesEdge!]!
+
+  """A list of \`Corge\` objects."""
+  nodes: [Corge]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -156,9 +159,9 @@ type CorgesEdge {
 
 """Methods to use when ordering \`Corge\`."""
 enum CorgesOrderBy {
-  NATURAL
   FOO_ID_ASC
   FOO_ID_DESC
+  NATURAL
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
@@ -167,50 +170,24 @@ enum CorgesOrderBy {
 scalar Cursor
 
 """
-A point in time as described by the [ISO
-8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
+A point in time as described by the [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
 """
 scalar Datetime
 
 type Foo implements Node {
-  """
-  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  """
-  nodeId: ID!
-  id: Int!
-  name: String!
-
   """Reads and enables pagination through a set of \`Baz\`."""
   bazsByFooId(
-    """Only read the first \`n\` values of the set."""
-    first: Int
-
-    """Only read the last \`n\` values of the set."""
-    last: Int
-
-    """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
     """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    """The method to use when ordering \`Baz\`."""
-    orderBy: [BazsOrderBy!] = [PRIMARY_KEY_ASC]
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
     condition: BazCondition
-  ): BazsConnection!
 
-  """Reads and enables pagination through a set of \`Qux\`."""
-  quxesByFooId(
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -218,54 +195,76 @@ type Foo implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
 
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
-    """The method to use when ordering \`Qux\`."""
-    orderBy: [QuxesOrderBy!] = [PRIMARY_KEY_ASC]
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: QuxCondition
-  ): QuxesConnection!
+    """The method to use when ordering \`Baz\`."""
+    orderBy: [BazsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): BazsConnection!
 
   """Reads and enables pagination through a set of \`Corge\`."""
   corgesByFooId(
-    """Only read the first \`n\` values of the set."""
-    first: Int
-
-    """Only read the last \`n\` values of the set."""
-    last: Int
-
-    """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
     """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    """The method to use when ordering \`Corge\`."""
-    orderBy: [CorgesOrderBy!] = [PRIMARY_KEY_ASC]
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
     condition: CorgeCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Corge\`."""
+    orderBy: [CorgesOrderBy!] = [PRIMARY_KEY_ASC]
   ): CorgesConnection!
+  id: Int!
+  name: String!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+
+  """Reads and enables pagination through a set of \`Qux\`."""
+  quxesByFooId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: QuxCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Qux\`."""
+    orderBy: [QuxesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): QuxesConnection!
 }
 
 """
@@ -278,13 +277,13 @@ input FooCondition {
 
 """A connection to a list of \`Foo\` values."""
 type FoosConnection {
-  """A list of \`Foo\` objects."""
-  nodes: [Foo]!
-
   """
   A list of edges which contains the \`Foo\` and cursor to aid in pagination.
   """
   edges: [FoosEdge!]!
+
+  """A list of \`Foo\` objects."""
+  nodes: [Foo]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -304,29 +303,29 @@ type FoosEdge {
 
 """Methods to use when ordering \`Foo\`."""
 enum FoosOrderBy {
-  NATURAL
   ID_ASC
   ID_DESC
+  NATURAL
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
 
 type Membership implements Node {
+  createdAt: Datetime!
+
   """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   """
   nodeId: ID!
-  personId: Int!
-  teamId: Int!
-  createdAt: Datetime!
 
   """Reads a single \`Person\` that is related to this \`Membership\`."""
   personByPersonId: Person
+  personId: Int!
+  teamId: Int!
 }
 
 """
-A condition to be used against \`Membership\` object types. All fields are tested
-for equality and combined with a logical ‘and.’
+A condition to be used against \`Membership\` object types. All fields are tested for equality and combined with a logical ‘and.’
 """
 input MembershipCondition {
   """Checks for equality with the object’s \`personId\` field."""
@@ -335,13 +334,13 @@ input MembershipCondition {
 
 """A connection to a list of \`Membership\` values."""
 type MembershipsConnection {
-  """A list of \`Membership\` objects."""
-  nodes: [Membership]!
-
   """
   A list of edges which contains the \`Membership\` and cursor to aid in pagination.
   """
   edges: [MembershipsEdge!]!
+
+  """A list of \`Membership\` objects."""
+  nodes: [Membership]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -378,6 +377,9 @@ interface Node {
 
 """Information about pagination in a connection."""
 type PageInfo {
+  """When paginating forwards, the cursor to continue."""
+  endCursor: Cursor
+
   """When paginating forwards, are there more items?"""
   hasNextPage: Boolean!
 
@@ -386,20 +388,17 @@ type PageInfo {
 
   """When paginating backwards, the cursor to continue."""
   startCursor: Cursor
-
-  """When paginating forwards, the cursor to continue."""
-  endCursor: Cursor
 }
 
 """A connection to a list of \`Person\` values."""
 type PeopleConnection {
-  """A list of \`Person\` objects."""
-  nodes: [Person]!
-
   """
   A list of edges which contains the \`Person\` and cursor to aid in pagination.
   """
   edges: [PeopleEdge!]!
+
+  """A list of \`Person\` objects."""
+  nodes: [Person]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -419,23 +418,29 @@ type PeopleEdge {
 
 """Methods to use when ordering \`Person\`."""
 enum PeopleOrderBy {
-  NATURAL
   ID_ASC
   ID_DESC
+  NATURAL
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
 
 type Person implements Node {
-  """
-  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  """
-  nodeId: ID!
   id: Int!
-  personName: String!
 
   """Reads and enables pagination through a set of \`Membership\`."""
   membershipsByPersonId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: MembershipCondition
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -443,25 +448,19 @@ type Person implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
 
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
     """The method to use when ordering \`Membership\`."""
     orderBy: [MembershipsOrderBy!] = [PRIMARY_KEY_ASC]
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: MembershipCondition
   ): MembershipsConnection!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  personName: String!
 }
 
 """
@@ -474,54 +473,19 @@ input PersonCondition {
 
 """The root query type which gives access points into the data universe."""
 type Query implements Node {
-  """
-  Exposes the root query type nested one level down. This is helpful for Relay 1
-  which can only query top level fields if they are in a particular form.
-  """
-  query: Query!
-
-  """
-  The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
-  """
-  nodeId: ID!
-
-  """Fetches an object given its globally unique \`ID\`."""
-  node(
-    """The globally unique \`ID\`."""
-    nodeId: ID!
-  ): Node
-
   """Reads and enables pagination through a set of \`Bar\`."""
   allBars(
-    """Only read the first \`n\` values of the set."""
-    first: Int
-
-    """Only read the last \`n\` values of the set."""
-    last: Int
-
-    """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
     """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    """The method to use when ordering \`Bar\`."""
-    orderBy: [BarsOrderBy!] = [PRIMARY_KEY_ASC]
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
     condition: BarCondition
-  ): BarsConnection
 
-  """Reads and enables pagination through a set of \`Baz\`."""
-  allBazs(
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -529,28 +493,27 @@ type Query implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
 
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
+    """The method to use when ordering \`Bar\`."""
+    orderBy: [BarsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): BarsConnection
 
+  """Reads and enables pagination through a set of \`Baz\`."""
+  allBazs(
     """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    """The method to use when ordering \`Baz\`."""
-    orderBy: [BazsOrderBy!] = [PRIMARY_KEY_ASC]
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
     condition: BazCondition
-  ): BazsConnection
 
-  """Reads and enables pagination through a set of \`Foo\`."""
-  allFoos(
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -558,28 +521,27 @@ type Query implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
 
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
+    """The method to use when ordering \`Baz\`."""
+    orderBy: [BazsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): BazsConnection
 
+  """Reads and enables pagination through a set of \`Foo\`."""
+  allFoos(
     """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    """The method to use when ordering \`Foo\`."""
-    orderBy: [FoosOrderBy!] = [PRIMARY_KEY_ASC]
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
     condition: FooCondition
-  ): FoosConnection
 
-  """Reads and enables pagination through a set of \`Membership\`."""
-  allMemberships(
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -587,28 +549,27 @@ type Query implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
 
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
+    """The method to use when ordering \`Foo\`."""
+    orderBy: [FoosOrderBy!] = [PRIMARY_KEY_ASC]
+  ): FoosConnection
 
+  """Reads and enables pagination through a set of \`Membership\`."""
+  allMemberships(
     """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    """The method to use when ordering \`Membership\`."""
-    orderBy: [MembershipsOrderBy!] = [PRIMARY_KEY_ASC]
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
     condition: MembershipCondition
-  ): MembershipsConnection
 
-  """Reads and enables pagination through a set of \`Person\`."""
-  allPeople(
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -616,28 +577,27 @@ type Query implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
 
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
+    """The method to use when ordering \`Membership\`."""
+    orderBy: [MembershipsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): MembershipsConnection
 
+  """Reads and enables pagination through a set of \`Person\`."""
+  allPeople(
     """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    """The method to use when ordering \`Person\`."""
-    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
     condition: PersonCondition
-  ): PeopleConnection
 
-  """Reads and enables pagination through a set of \`Team\`."""
-  allTeams(
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -645,57 +605,69 @@ type Query implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
 
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
+    """The method to use when ordering \`Person\`."""
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PeopleConnection
 
+  """Reads and enables pagination through a set of \`Team\`."""
+  allTeams(
     """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    """The method to use when ordering \`Team\`."""
-    orderBy: [TeamsOrderBy!] = [PRIMARY_KEY_ASC]
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
     condition: TeamCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Team\`."""
+    orderBy: [TeamsOrderBy!] = [PRIMARY_KEY_ASC]
   ): TeamsConnection
-  barById(id: Int!): Bar
-  bazByFooIdAndBarId(fooId: Int!, barId: Int!): Baz
-  corgeByFooIdAndBarId(fooId: Int!, barId: Int!): Corge
-  fooById(id: Int!): Foo
-  membershipByPersonIdAndTeamId(personId: Int!, teamId: Int!): Membership
-  personById(id: Int!): Person
-  quxByFooIdAndBarId(fooId: Int!, barId: Int!): Qux
-  teamById(id: Int!): Team
 
   """Reads a single \`Bar\` using its globally unique \`ID\`."""
   bar(
     """The globally unique \`ID\` to be used in selecting a single \`Bar\`."""
     nodeId: ID!
   ): Bar
+  barById(id: Int!): Bar
 
   """Reads a single \`Baz\` using its globally unique \`ID\`."""
   baz(
     """The globally unique \`ID\` to be used in selecting a single \`Baz\`."""
     nodeId: ID!
   ): Baz
+  bazByFooIdAndBarId(barId: Int!, fooId: Int!): Baz
 
   """Reads a single \`Corge\` using its globally unique \`ID\`."""
   corge(
     """The globally unique \`ID\` to be used in selecting a single \`Corge\`."""
     nodeId: ID!
   ): Corge
+  corgeByFooIdAndBarId(barId: Int!, fooId: Int!): Corge
 
   """Reads a single \`Foo\` using its globally unique \`ID\`."""
   foo(
     """The globally unique \`ID\` to be used in selecting a single \`Foo\`."""
     nodeId: ID!
   ): Foo
+  fooById(id: Int!): Foo
 
   """Reads a single \`Membership\` using its globally unique \`ID\`."""
   membership(
@@ -704,36 +676,57 @@ type Query implements Node {
     """
     nodeId: ID!
   ): Membership
+  membershipByPersonIdAndTeamId(personId: Int!, teamId: Int!): Membership
+
+  """Fetches an object given its globally unique \`ID\`."""
+  node(
+    """The globally unique \`ID\`."""
+    nodeId: ID!
+  ): Node
+
+  """
+  The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
+  """
+  nodeId: ID!
 
   """Reads a single \`Person\` using its globally unique \`ID\`."""
   person(
     """The globally unique \`ID\` to be used in selecting a single \`Person\`."""
     nodeId: ID!
   ): Person
+  personById(id: Int!): Person
+
+  """
+  Exposes the root query type nested one level down. This is helpful for Relay 1 which can only query top level fields if they are in a particular form.
+  """
+  query: Query!
 
   """Reads a single \`Qux\` using its globally unique \`ID\`."""
   qux(
     """The globally unique \`ID\` to be used in selecting a single \`Qux\`."""
     nodeId: ID!
   ): Qux
+  quxByFooIdAndBarId(barId: Int!, fooId: Int!): Qux
 
   """Reads a single \`Team\` using its globally unique \`ID\`."""
   team(
     """The globally unique \`ID\` to be used in selecting a single \`Team\`."""
     nodeId: ID!
   ): Team
+  teamById(id: Int!): Team
 }
 
 type Qux implements Node {
-  """
-  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  """
-  nodeId: ID!
-  fooId: Int!
   barId: Int!
 
   """Reads a single \`Foo\` that is related to this \`Qux\`."""
   fooByFooId: Foo
+  fooId: Int!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
 }
 
 """
@@ -746,13 +739,13 @@ input QuxCondition {
 
 """A connection to a list of \`Qux\` values."""
 type QuxesConnection {
-  """A list of \`Qux\` objects."""
-  nodes: [Qux]!
-
   """
   A list of edges which contains the \`Qux\` and cursor to aid in pagination.
   """
   edges: [QuxesEdge!]!
+
+  """A list of \`Qux\` objects."""
+  nodes: [Qux]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -772,19 +765,20 @@ type QuxesEdge {
 
 """Methods to use when ordering \`Qux\`."""
 enum QuxesOrderBy {
-  NATURAL
   FOO_ID_ASC
   FOO_ID_DESC
+  NATURAL
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
 
 type Team implements Node {
+  id: Int!
+
   """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   """
   nodeId: ID!
-  id: Int!
   teamName: String!
 }
 
@@ -798,13 +792,13 @@ input TeamCondition {
 
 """A connection to a list of \`Team\` values."""
 type TeamsConnection {
-  """A list of \`Team\` objects."""
-  nodes: [Team]!
-
   """
   A list of edges which contains the \`Team\` and cursor to aid in pagination.
   """
   edges: [TeamsEdge!]!
+
+  """A list of \`Team\` objects."""
+  nodes: [Team]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -824,9 +818,9 @@ type TeamsEdge {
 
 """Methods to use when ordering \`Team\`."""
 enum TeamsOrderBy {
-  NATURAL
   ID_ASC
   ID_DESC
+  NATURAL
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }

--- a/__tests__/integration/schema/__snapshots__/p.simpleCollectionsBoth.test.js.snap
+++ b/__tests__/integration/schema/__snapshots__/p.simpleCollectionsBoth.test.js.snap
@@ -2,90 +2,41 @@
 
 exports[`prints a schema with the many-to-many plugin 1`] = `
 "type Bar implements Node {
-  """
-  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  """
-  nodeId: ID!
-  id: Int!
-  name: String!
-
-  """Reads and enables pagination through a set of \`Qux\`."""
-  quxesByBarId(
-    """Only read the first \`n\` values of the set."""
-    first: Int
-
-    """Only read the last \`n\` values of the set."""
-    last: Int
-
-    """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
-    """The method to use when ordering \`Qux\`."""
-    orderBy: [QuxesOrderBy!] = [PRIMARY_KEY_ASC]
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: QuxCondition
-  ): QuxesConnection!
-
-  """Reads and enables pagination through a set of \`Qux\`."""
-  quxesByBarIdList(
-    """Only read the first \`n\` values of the set."""
-    first: Int
-
-    """Skip the first \`n\` values."""
-    offset: Int
-
-    """The method to use when ordering \`Qux\`."""
-    orderBy: [QuxesOrderBy!]
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: QuxCondition
-  ): [Qux!]!
-
   """Reads and enables pagination through a set of \`Corge\`."""
   corgesByBarId(
-    """Only read the first \`n\` values of the set."""
-    first: Int
-
-    """Only read the last \`n\` values of the set."""
-    last: Int
-
-    """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
     """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    """The method to use when ordering \`Corge\`."""
-    orderBy: [CorgesOrderBy!] = [PRIMARY_KEY_ASC]
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
     condition: CorgeCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Corge\`."""
+    orderBy: [CorgesOrderBy!] = [PRIMARY_KEY_ASC]
   ): CorgesConnection!
 
   """Reads and enables pagination through a set of \`Corge\`."""
   corgesByBarIdList(
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CorgeCondition
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -94,12 +45,59 @@ exports[`prints a schema with the many-to-many plugin 1`] = `
 
     """The method to use when ordering \`Corge\`."""
     orderBy: [CorgesOrderBy!]
+  ): [Corge!]!
+  id: Int!
+  name: String!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+
+  """Reads and enables pagination through a set of \`Qux\`."""
+  quxesByBarId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CorgeCondition
-  ): [Corge!]!
+    condition: QuxCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Qux\`."""
+    orderBy: [QuxesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): QuxesConnection!
+
+  """Reads and enables pagination through a set of \`Qux\`."""
+  quxesByBarIdList(
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: QuxCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+
+    """The method to use when ordering \`Qux\`."""
+    orderBy: [QuxesOrderBy!]
+  ): [Qux!]!
 }
 
 """
@@ -115,13 +113,13 @@ input BarCondition {
 
 """A connection to a list of \`Bar\` values."""
 type BarsConnection {
-  """A list of \`Bar\` objects."""
-  nodes: [Bar]!
-
   """
   A list of edges which contains the \`Bar\` and cursor to aid in pagination.
   """
   edges: [BarsEdge!]!
+
+  """A list of \`Bar\` objects."""
+  nodes: [Bar]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -141,47 +139,48 @@ type BarsEdge {
 
 """Methods to use when ordering \`Bar\`."""
 enum BarsOrderBy {
-  NATURAL
   ID_ASC
   ID_DESC
   NAME_ASC
   NAME_DESC
+  NATURAL
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
 
 type Baz implements Node {
-  """
-  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  """
-  nodeId: ID!
-  fooId: Int!
   barId: Int!
 
   """Reads a single \`Foo\` that is related to this \`Baz\`."""
   fooByFooId: Foo
+  fooId: Int!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
 }
 
 """
 A condition to be used against \`Baz\` object types. All fields are tested for equality and combined with a logical ‘and.’
 """
 input BazCondition {
-  """Checks for equality with the object’s \`fooId\` field."""
-  fooId: Int
-
   """Checks for equality with the object’s \`barId\` field."""
   barId: Int
+
+  """Checks for equality with the object’s \`fooId\` field."""
+  fooId: Int
 }
 
 """A connection to a list of \`Baz\` values."""
 type BazsConnection {
-  """A list of \`Baz\` objects."""
-  nodes: [Baz]!
-
   """
   A list of edges which contains the \`Baz\` and cursor to aid in pagination.
   """
   edges: [BazsEdge!]!
+
+  """A list of \`Baz\` objects."""
+  nodes: [Baz]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -201,50 +200,50 @@ type BazsEdge {
 
 """Methods to use when ordering \`Baz\`."""
 enum BazsOrderBy {
-  NATURAL
-  FOO_ID_ASC
-  FOO_ID_DESC
   BAR_ID_ASC
   BAR_ID_DESC
+  FOO_ID_ASC
+  FOO_ID_DESC
+  NATURAL
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
 
 type Corge implements Node {
-  """
-  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  """
-  nodeId: ID!
-  fooId: Int!
+  """Reads a single \`Bar\` that is related to this \`Corge\`."""
+  barByBarId: Bar
   barId: Int!
 
   """Reads a single \`Foo\` that is related to this \`Corge\`."""
   fooByFooId: Foo
+  fooId: Int!
 
-  """Reads a single \`Bar\` that is related to this \`Corge\`."""
-  barByBarId: Bar
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
 }
 
 """
 A condition to be used against \`Corge\` object types. All fields are tested for equality and combined with a logical ‘and.’
 """
 input CorgeCondition {
-  """Checks for equality with the object’s \`fooId\` field."""
-  fooId: Int
-
   """Checks for equality with the object’s \`barId\` field."""
   barId: Int
+
+  """Checks for equality with the object’s \`fooId\` field."""
+  fooId: Int
 }
 
 """A connection to a list of \`Corge\` values."""
 type CorgesConnection {
-  """A list of \`Corge\` objects."""
-  nodes: [Corge]!
-
   """
   A list of edges which contains the \`Corge\` and cursor to aid in pagination.
   """
   edges: [CorgesEdge!]!
+
+  """A list of \`Corge\` objects."""
+  nodes: [Corge]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -264,11 +263,11 @@ type CorgesEdge {
 
 """Methods to use when ordering \`Corge\`."""
 enum CorgesOrderBy {
-  NATURAL
-  FOO_ID_ASC
-  FOO_ID_DESC
   BAR_ID_ASC
   BAR_ID_DESC
+  FOO_ID_ASC
+  FOO_ID_DESC
+  NATURAL
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
@@ -277,21 +276,24 @@ enum CorgesOrderBy {
 scalar Cursor
 
 """
-A point in time as described by the [ISO
-8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
+A point in time as described by the [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
 """
 scalar Datetime
 
 type Foo implements Node {
-  """
-  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  """
-  nodeId: ID!
-  id: Int!
-  name: String!
-
   """Reads and enables pagination through a set of \`Baz\`."""
   bazsByFooId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BazCondition
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -299,28 +301,21 @@ type Foo implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
 
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
     """The method to use when ordering \`Baz\`."""
     orderBy: [BazsOrderBy!] = [PRIMARY_KEY_ASC]
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: BazCondition
   ): BazsConnection!
 
   """Reads and enables pagination through a set of \`Baz\`."""
   bazsByFooIdList(
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BazCondition
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -329,90 +324,43 @@ type Foo implements Node {
 
     """The method to use when ordering \`Baz\`."""
     orderBy: [BazsOrderBy!]
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: BazCondition
   ): [Baz!]!
-
-  """Reads and enables pagination through a set of \`Qux\`."""
-  quxesByFooId(
-    """Only read the first \`n\` values of the set."""
-    first: Int
-
-    """Only read the last \`n\` values of the set."""
-    last: Int
-
-    """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
-    """The method to use when ordering \`Qux\`."""
-    orderBy: [QuxesOrderBy!] = [PRIMARY_KEY_ASC]
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: QuxCondition
-  ): QuxesConnection!
-
-  """Reads and enables pagination through a set of \`Qux\`."""
-  quxesByFooIdList(
-    """Only read the first \`n\` values of the set."""
-    first: Int
-
-    """Skip the first \`n\` values."""
-    offset: Int
-
-    """The method to use when ordering \`Qux\`."""
-    orderBy: [QuxesOrderBy!]
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: QuxCondition
-  ): [Qux!]!
 
   """Reads and enables pagination through a set of \`Corge\`."""
   corgesByFooId(
-    """Only read the first \`n\` values of the set."""
-    first: Int
-
-    """Only read the last \`n\` values of the set."""
-    last: Int
-
-    """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
     """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    """The method to use when ordering \`Corge\`."""
-    orderBy: [CorgesOrderBy!] = [PRIMARY_KEY_ASC]
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
     condition: CorgeCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Corge\`."""
+    orderBy: [CorgesOrderBy!] = [PRIMARY_KEY_ASC]
   ): CorgesConnection!
 
   """Reads and enables pagination through a set of \`Corge\`."""
   corgesByFooIdList(
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CorgeCondition
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -421,12 +369,59 @@ type Foo implements Node {
 
     """The method to use when ordering \`Corge\`."""
     orderBy: [CorgesOrderBy!]
+  ): [Corge!]!
+  id: Int!
+  name: String!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+
+  """Reads and enables pagination through a set of \`Qux\`."""
+  quxesByFooId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: CorgeCondition
-  ): [Corge!]!
+    condition: QuxCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Qux\`."""
+    orderBy: [QuxesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): QuxesConnection!
+
+  """Reads and enables pagination through a set of \`Qux\`."""
+  quxesByFooIdList(
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: QuxCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+
+    """The method to use when ordering \`Qux\`."""
+    orderBy: [QuxesOrderBy!]
+  ): [Qux!]!
 }
 
 """
@@ -442,13 +437,13 @@ input FooCondition {
 
 """A connection to a list of \`Foo\` values."""
 type FoosConnection {
-  """A list of \`Foo\` objects."""
-  nodes: [Foo]!
-
   """
   A list of edges which contains the \`Foo\` and cursor to aid in pagination.
   """
   edges: [FoosEdge!]!
+
+  """A list of \`Foo\` objects."""
+  nodes: [Foo]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -468,55 +463,55 @@ type FoosEdge {
 
 """Methods to use when ordering \`Foo\`."""
 enum FoosOrderBy {
-  NATURAL
   ID_ASC
   ID_DESC
   NAME_ASC
   NAME_DESC
+  NATURAL
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
 
 type Membership implements Node {
+  createdAt: Datetime!
+
   """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   """
   nodeId: ID!
-  personId: Int!
-  teamId: Int!
-  createdAt: Datetime!
 
   """Reads a single \`Person\` that is related to this \`Membership\`."""
   personByPersonId: Person
+  personId: Int!
 
   """Reads a single \`Team\` that is related to this \`Membership\`."""
   teamByTeamId: Team
+  teamId: Int!
 }
 
 """
-A condition to be used against \`Membership\` object types. All fields are tested
-for equality and combined with a logical ‘and.’
+A condition to be used against \`Membership\` object types. All fields are tested for equality and combined with a logical ‘and.’
 """
 input MembershipCondition {
+  """Checks for equality with the object’s \`createdAt\` field."""
+  createdAt: Datetime
+
   """Checks for equality with the object’s \`personId\` field."""
   personId: Int
 
   """Checks for equality with the object’s \`teamId\` field."""
   teamId: Int
-
-  """Checks for equality with the object’s \`createdAt\` field."""
-  createdAt: Datetime
 }
 
 """A connection to a list of \`Membership\` values."""
 type MembershipsConnection {
-  """A list of \`Membership\` objects."""
-  nodes: [Membership]!
-
   """
   A list of edges which contains the \`Membership\` and cursor to aid in pagination.
   """
   edges: [MembershipsEdge!]!
+
+  """A list of \`Membership\` objects."""
+  nodes: [Membership]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -536,15 +531,15 @@ type MembershipsEdge {
 
 """Methods to use when ordering \`Membership\`."""
 enum MembershipsOrderBy {
+  CREATED_AT_ASC
+  CREATED_AT_DESC
   NATURAL
   PERSON_ID_ASC
   PERSON_ID_DESC
-  TEAM_ID_ASC
-  TEAM_ID_DESC
-  CREATED_AT_ASC
-  CREATED_AT_DESC
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
+  TEAM_ID_ASC
+  TEAM_ID_DESC
 }
 
 """An object with a globally unique \`ID\`."""
@@ -557,6 +552,9 @@ interface Node {
 
 """Information about pagination in a connection."""
 type PageInfo {
+  """When paginating forwards, the cursor to continue."""
+  endCursor: Cursor
+
   """When paginating forwards, are there more items?"""
   hasNextPage: Boolean!
 
@@ -565,20 +563,17 @@ type PageInfo {
 
   """When paginating backwards, the cursor to continue."""
   startCursor: Cursor
-
-  """When paginating forwards, the cursor to continue."""
-  endCursor: Cursor
 }
 
 """A connection to a list of \`Person\` values."""
 type PeopleConnection {
-  """A list of \`Person\` objects."""
-  nodes: [Person]!
-
   """
   A list of edges which contains the \`Person\` and cursor to aid in pagination.
   """
   edges: [PeopleEdge!]!
+
+  """A list of \`Person\` objects."""
+  nodes: [Person]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -598,9 +593,9 @@ type PeopleEdge {
 
 """Methods to use when ordering \`Person\`."""
 enum PeopleOrderBy {
-  NATURAL
   ID_ASC
   ID_DESC
+  NATURAL
   PERSON_NAME_ASC
   PERSON_NAME_DESC
   PRIMARY_KEY_ASC
@@ -608,15 +603,21 @@ enum PeopleOrderBy {
 }
 
 type Person implements Node {
-  """
-  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  """
-  nodeId: ID!
   id: Int!
-  personName: String!
 
   """Reads and enables pagination through a set of \`Membership\`."""
   membershipsByPersonId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: MembershipCondition
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -624,28 +625,21 @@ type Person implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
 
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
     """The method to use when ordering \`Membership\`."""
     orderBy: [MembershipsOrderBy!] = [PRIMARY_KEY_ASC]
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: MembershipCondition
   ): MembershipsConnection!
 
   """Reads and enables pagination through a set of \`Membership\`."""
   membershipsByPersonIdList(
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: MembershipCondition
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -654,15 +648,27 @@ type Person implements Node {
 
     """The method to use when ordering \`Membership\`."""
     orderBy: [MembershipsOrderBy!]
+  ): [Membership!]!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  personName: String!
+
+  """Reads and enables pagination through a set of \`Team\`."""
+  teamsByMembershipPersonIdAndTeamId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: MembershipCondition
-  ): [Membership!]!
+    condition: TeamCondition
 
-  """Reads and enables pagination through a set of \`Team\`."""
-  teamsByMembershipPersonIdAndTeamId(
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -670,24 +676,12 @@ type Person implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
 
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
     """The method to use when ordering \`Team\`."""
     orderBy: [TeamsOrderBy!] = [PRIMARY_KEY_ASC]
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: TeamCondition
   ): PersonTeamsByMembershipPersonIdAndTeamIdManyToManyConnection!
 }
 
@@ -704,13 +698,13 @@ input PersonCondition {
 
 """A connection to a list of \`Team\` values, with data from \`Membership\`."""
 type PersonTeamsByMembershipPersonIdAndTeamIdManyToManyConnection {
-  """A list of \`Team\` objects."""
-  nodes: [Team]!
-
   """
   A list of edges which contains the \`Team\`, info from the \`Membership\`, and the cursor to aid in pagination.
   """
   edges: [PersonTeamsByMembershipPersonIdAndTeamIdManyToManyEdge!]!
+
+  """A list of \`Team\` objects."""
+  nodes: [Team]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -721,35 +715,30 @@ type PersonTeamsByMembershipPersonIdAndTeamIdManyToManyConnection {
 
 """A \`Team\` edge in the connection, with data from \`Membership\`."""
 type PersonTeamsByMembershipPersonIdAndTeamIdManyToManyEdge {
+  createdAt: Datetime!
+
   """A cursor for use in pagination."""
   cursor: Cursor
 
   """The \`Team\` at the end of the edge."""
   node: Team
-  createdAt: Datetime!
 }
 
 """The root query type which gives access points into the data universe."""
 type Query implements Node {
-  """
-  Exposes the root query type nested one level down. This is helpful for Relay 1
-  which can only query top level fields if they are in a particular form.
-  """
-  query: Query!
-
-  """
-  The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
-  """
-  nodeId: ID!
-
-  """Fetches an object given its globally unique \`ID\`."""
-  node(
-    """The globally unique \`ID\`."""
-    nodeId: ID!
-  ): Node
-
   """Reads and enables pagination through a set of \`Bar\`."""
   allBars(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BarCondition
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -757,28 +746,21 @@ type Query implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
 
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
     """The method to use when ordering \`Bar\`."""
     orderBy: [BarsOrderBy!] = [PRIMARY_KEY_ASC]
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: BarCondition
   ): BarsConnection
 
   """Reads a set of \`Bar\`."""
   allBarsList(
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BarCondition
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -787,15 +769,21 @@ type Query implements Node {
 
     """The method to use when ordering \`Bar\`."""
     orderBy: [BarsOrderBy!]
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: BarCondition
   ): [Bar!]
 
   """Reads and enables pagination through a set of \`Baz\`."""
   allBazs(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BazCondition
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -803,28 +791,21 @@ type Query implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
 
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
     """The method to use when ordering \`Baz\`."""
     orderBy: [BazsOrderBy!] = [PRIMARY_KEY_ASC]
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: BazCondition
   ): BazsConnection
 
   """Reads a set of \`Baz\`."""
   allBazsList(
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: BazCondition
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -833,15 +814,21 @@ type Query implements Node {
 
     """The method to use when ordering \`Baz\`."""
     orderBy: [BazsOrderBy!]
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: BazCondition
   ): [Baz!]
 
   """Reads and enables pagination through a set of \`Foo\`."""
   allFoos(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: FooCondition
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -849,28 +836,21 @@ type Query implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
 
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
     """The method to use when ordering \`Foo\`."""
     orderBy: [FoosOrderBy!] = [PRIMARY_KEY_ASC]
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: FooCondition
   ): FoosConnection
 
   """Reads a set of \`Foo\`."""
   allFoosList(
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: FooCondition
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -879,15 +859,21 @@ type Query implements Node {
 
     """The method to use when ordering \`Foo\`."""
     orderBy: [FoosOrderBy!]
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: FooCondition
   ): [Foo!]
 
   """Reads and enables pagination through a set of \`Membership\`."""
   allMemberships(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: MembershipCondition
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -895,28 +881,21 @@ type Query implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
 
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
     """The method to use when ordering \`Membership\`."""
     orderBy: [MembershipsOrderBy!] = [PRIMARY_KEY_ASC]
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: MembershipCondition
   ): MembershipsConnection
 
   """Reads a set of \`Membership\`."""
   allMembershipsList(
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: MembershipCondition
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -925,15 +904,21 @@ type Query implements Node {
 
     """The method to use when ordering \`Membership\`."""
     orderBy: [MembershipsOrderBy!]
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: MembershipCondition
   ): [Membership!]
 
   """Reads and enables pagination through a set of \`Person\`."""
   allPeople(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -941,28 +926,21 @@ type Query implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
 
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
     """The method to use when ordering \`Person\`."""
     orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: PersonCondition
   ): PeopleConnection
 
   """Reads a set of \`Person\`."""
   allPeopleList(
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -971,15 +949,21 @@ type Query implements Node {
 
     """The method to use when ordering \`Person\`."""
     orderBy: [PeopleOrderBy!]
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: PersonCondition
   ): [Person!]
 
   """Reads and enables pagination through a set of \`Team\`."""
   allTeams(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: TeamCondition
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -987,28 +971,21 @@ type Query implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
 
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
     """The method to use when ordering \`Team\`."""
     orderBy: [TeamsOrderBy!] = [PRIMARY_KEY_ASC]
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: TeamCondition
   ): TeamsConnection
 
   """Reads a set of \`Team\`."""
   allTeamsList(
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: TeamCondition
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -1017,44 +994,35 @@ type Query implements Node {
 
     """The method to use when ordering \`Team\`."""
     orderBy: [TeamsOrderBy!]
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: TeamCondition
   ): [Team!]
-  barById(id: Int!): Bar
-  bazByFooIdAndBarId(fooId: Int!, barId: Int!): Baz
-  corgeByFooIdAndBarId(fooId: Int!, barId: Int!): Corge
-  fooById(id: Int!): Foo
-  membershipByPersonIdAndTeamId(personId: Int!, teamId: Int!): Membership
-  personById(id: Int!): Person
-  quxByFooIdAndBarId(fooId: Int!, barId: Int!): Qux
-  teamById(id: Int!): Team
 
   """Reads a single \`Bar\` using its globally unique \`ID\`."""
   bar(
     """The globally unique \`ID\` to be used in selecting a single \`Bar\`."""
     nodeId: ID!
   ): Bar
+  barById(id: Int!): Bar
 
   """Reads a single \`Baz\` using its globally unique \`ID\`."""
   baz(
     """The globally unique \`ID\` to be used in selecting a single \`Baz\`."""
     nodeId: ID!
   ): Baz
+  bazByFooIdAndBarId(barId: Int!, fooId: Int!): Baz
 
   """Reads a single \`Corge\` using its globally unique \`ID\`."""
   corge(
     """The globally unique \`ID\` to be used in selecting a single \`Corge\`."""
     nodeId: ID!
   ): Corge
+  corgeByFooIdAndBarId(barId: Int!, fooId: Int!): Corge
 
   """Reads a single \`Foo\` using its globally unique \`ID\`."""
   foo(
     """The globally unique \`ID\` to be used in selecting a single \`Foo\`."""
     nodeId: ID!
   ): Foo
+  fooById(id: Int!): Foo
 
   """Reads a single \`Membership\` using its globally unique \`ID\`."""
   membership(
@@ -1063,61 +1031,81 @@ type Query implements Node {
     """
     nodeId: ID!
   ): Membership
+  membershipByPersonIdAndTeamId(personId: Int!, teamId: Int!): Membership
+
+  """Fetches an object given its globally unique \`ID\`."""
+  node(
+    """The globally unique \`ID\`."""
+    nodeId: ID!
+  ): Node
+
+  """
+  The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
+  """
+  nodeId: ID!
 
   """Reads a single \`Person\` using its globally unique \`ID\`."""
   person(
     """The globally unique \`ID\` to be used in selecting a single \`Person\`."""
     nodeId: ID!
   ): Person
+  personById(id: Int!): Person
+
+  """
+  Exposes the root query type nested one level down. This is helpful for Relay 1 which can only query top level fields if they are in a particular form.
+  """
+  query: Query!
 
   """Reads a single \`Qux\` using its globally unique \`ID\`."""
   qux(
     """The globally unique \`ID\` to be used in selecting a single \`Qux\`."""
     nodeId: ID!
   ): Qux
+  quxByFooIdAndBarId(barId: Int!, fooId: Int!): Qux
 
   """Reads a single \`Team\` using its globally unique \`ID\`."""
   team(
     """The globally unique \`ID\` to be used in selecting a single \`Team\`."""
     nodeId: ID!
   ): Team
+  teamById(id: Int!): Team
 }
 
 type Qux implements Node {
-  """
-  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  """
-  nodeId: ID!
-  fooId: Int!
+  """Reads a single \`Bar\` that is related to this \`Qux\`."""
+  barByBarId: Bar
   barId: Int!
 
   """Reads a single \`Foo\` that is related to this \`Qux\`."""
   fooByFooId: Foo
+  fooId: Int!
 
-  """Reads a single \`Bar\` that is related to this \`Qux\`."""
-  barByBarId: Bar
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
 }
 
 """
 A condition to be used against \`Qux\` object types. All fields are tested for equality and combined with a logical ‘and.’
 """
 input QuxCondition {
-  """Checks for equality with the object’s \`fooId\` field."""
-  fooId: Int
-
   """Checks for equality with the object’s \`barId\` field."""
   barId: Int
+
+  """Checks for equality with the object’s \`fooId\` field."""
+  fooId: Int
 }
 
 """A connection to a list of \`Qux\` values."""
 type QuxesConnection {
-  """A list of \`Qux\` objects."""
-  nodes: [Qux]!
-
   """
   A list of edges which contains the \`Qux\` and cursor to aid in pagination.
   """
   edges: [QuxesEdge!]!
+
+  """A list of \`Qux\` objects."""
+  nodes: [Qux]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -1137,83 +1125,53 @@ type QuxesEdge {
 
 """Methods to use when ordering \`Qux\`."""
 enum QuxesOrderBy {
-  NATURAL
-  FOO_ID_ASC
-  FOO_ID_DESC
   BAR_ID_ASC
   BAR_ID_DESC
+  FOO_ID_ASC
+  FOO_ID_DESC
+  NATURAL
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
 
 type Team implements Node {
-  """
-  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  """
-  nodeId: ID!
   id: Int!
-  teamName: String!
-
-  """Reads and enables pagination through a set of \`Membership\`."""
-  membershipsByTeamId(
-    """Only read the first \`n\` values of the set."""
-    first: Int
-
-    """Only read the last \`n\` values of the set."""
-    last: Int
-
-    """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
-    """The method to use when ordering \`Membership\`."""
-    orderBy: [MembershipsOrderBy!] = [PRIMARY_KEY_ASC]
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: MembershipCondition
-  ): MembershipsConnection!
 
   """Reads and enables pagination through a set of \`Person\`."""
   members(
-    """Only read the first \`n\` values of the set."""
-    first: Int
-
-    """Only read the last \`n\` values of the set."""
-    last: Int
-
-    """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
     """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    """The method to use when ordering \`Person\`."""
-    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
     condition: PersonCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Person\`."""
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
   ): TeamMembersManyToManyConnection!
 
   """Reads and enables pagination through a set of \`Person\`."""
   membersList(
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -1222,12 +1180,41 @@ type Team implements Node {
 
     """The method to use when ordering \`Person\`."""
     orderBy: [PeopleOrderBy!]
+  ): [Person!]!
+
+  """Reads and enables pagination through a set of \`Membership\`."""
+  membershipsByTeamId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
-    condition: PersonCondition
-  ): [Person!]!
+    condition: MembershipCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Membership\`."""
+    orderBy: [MembershipsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): MembershipsConnection!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  teamName: String!
 }
 
 """
@@ -1245,13 +1232,13 @@ input TeamCondition {
 A connection to a list of \`Person\` values, with data from \`Membership\`.
 """
 type TeamMembersManyToManyConnection {
-  """A list of \`Person\` objects."""
-  nodes: [Person]!
-
   """
   A list of edges which contains the \`Person\`, info from the \`Membership\`, and the cursor to aid in pagination.
   """
   edges: [TeamMembersManyToManyEdge!]!
+
+  """A list of \`Person\` objects."""
+  nodes: [Person]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -1262,23 +1249,24 @@ type TeamMembersManyToManyConnection {
 
 """A \`Person\` edge in the connection, with data from \`Membership\`."""
 type TeamMembersManyToManyEdge {
+  createdAt: Datetime!
+
   """A cursor for use in pagination."""
   cursor: Cursor
 
   """The \`Person\` at the end of the edge."""
   node: Person
-  createdAt: Datetime!
 }
 
 """A connection to a list of \`Team\` values."""
 type TeamsConnection {
-  """A list of \`Team\` objects."""
-  nodes: [Team]!
-
   """
   A list of edges which contains the \`Team\` and cursor to aid in pagination.
   """
   edges: [TeamsEdge!]!
+
+  """A list of \`Team\` objects."""
+  nodes: [Team]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -1298,13 +1286,13 @@ type TeamsEdge {
 
 """Methods to use when ordering \`Team\`."""
 enum TeamsOrderBy {
-  NATURAL
   ID_ASC
   ID_DESC
-  TEAM_NAME_ASC
-  TEAM_NAME_DESC
+  NATURAL
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
+  TEAM_NAME_ASC
+  TEAM_NAME_DESC
 }
 "
 `;

--- a/__tests__/integration/schema/__snapshots__/p.test.js.snap
+++ b/__tests__/integration/schema/__snapshots__/p.test.js.snap
@@ -2,70 +2,68 @@
 
 exports[`prints a schema with the many-to-many plugin 1`] = `
 "type Bar implements Node {
-  """
-  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  """
-  nodeId: ID!
-  id: Int!
-  name: String!
-
-  """Reads and enables pagination through a set of \`Qux\`."""
-  quxesByBarId(
-    """Only read the first \`n\` values of the set."""
-    first: Int
-
-    """Only read the last \`n\` values of the set."""
-    last: Int
-
-    """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
-    """The method to use when ordering \`Qux\`."""
-    orderBy: [QuxesOrderBy!] = [PRIMARY_KEY_ASC]
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: QuxCondition
-  ): QuxesConnection!
-
   """Reads and enables pagination through a set of \`Corge\`."""
   corgesByBarId(
-    """Only read the first \`n\` values of the set."""
-    first: Int
-
-    """Only read the last \`n\` values of the set."""
-    last: Int
-
-    """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
     """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    """The method to use when ordering \`Corge\`."""
-    orderBy: [CorgesOrderBy!] = [PRIMARY_KEY_ASC]
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
     condition: CorgeCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Corge\`."""
+    orderBy: [CorgesOrderBy!] = [PRIMARY_KEY_ASC]
   ): CorgesConnection!
+  id: Int!
+  name: String!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+
+  """Reads and enables pagination through a set of \`Qux\`."""
+  quxesByBarId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: QuxCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Qux\`."""
+    orderBy: [QuxesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): QuxesConnection!
 }
 
 """
@@ -81,13 +79,13 @@ input BarCondition {
 
 """A connection to a list of \`Bar\` values."""
 type BarsConnection {
-  """A list of \`Bar\` objects."""
-  nodes: [Bar]!
-
   """
   A list of edges which contains the \`Bar\` and cursor to aid in pagination.
   """
   edges: [BarsEdge!]!
+
+  """A list of \`Bar\` objects."""
+  nodes: [Bar]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -107,47 +105,48 @@ type BarsEdge {
 
 """Methods to use when ordering \`Bar\`."""
 enum BarsOrderBy {
-  NATURAL
   ID_ASC
   ID_DESC
   NAME_ASC
   NAME_DESC
+  NATURAL
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
 
 type Baz implements Node {
-  """
-  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  """
-  nodeId: ID!
-  fooId: Int!
   barId: Int!
 
   """Reads a single \`Foo\` that is related to this \`Baz\`."""
   fooByFooId: Foo
+  fooId: Int!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
 }
 
 """
 A condition to be used against \`Baz\` object types. All fields are tested for equality and combined with a logical ‘and.’
 """
 input BazCondition {
-  """Checks for equality with the object’s \`fooId\` field."""
-  fooId: Int
-
   """Checks for equality with the object’s \`barId\` field."""
   barId: Int
+
+  """Checks for equality with the object’s \`fooId\` field."""
+  fooId: Int
 }
 
 """A connection to a list of \`Baz\` values."""
 type BazsConnection {
-  """A list of \`Baz\` objects."""
-  nodes: [Baz]!
-
   """
   A list of edges which contains the \`Baz\` and cursor to aid in pagination.
   """
   edges: [BazsEdge!]!
+
+  """A list of \`Baz\` objects."""
+  nodes: [Baz]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -167,50 +166,50 @@ type BazsEdge {
 
 """Methods to use when ordering \`Baz\`."""
 enum BazsOrderBy {
-  NATURAL
-  FOO_ID_ASC
-  FOO_ID_DESC
   BAR_ID_ASC
   BAR_ID_DESC
+  FOO_ID_ASC
+  FOO_ID_DESC
+  NATURAL
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
 
 type Corge implements Node {
-  """
-  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  """
-  nodeId: ID!
-  fooId: Int!
+  """Reads a single \`Bar\` that is related to this \`Corge\`."""
+  barByBarId: Bar
   barId: Int!
 
   """Reads a single \`Foo\` that is related to this \`Corge\`."""
   fooByFooId: Foo
+  fooId: Int!
 
-  """Reads a single \`Bar\` that is related to this \`Corge\`."""
-  barByBarId: Bar
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
 }
 
 """
 A condition to be used against \`Corge\` object types. All fields are tested for equality and combined with a logical ‘and.’
 """
 input CorgeCondition {
-  """Checks for equality with the object’s \`fooId\` field."""
-  fooId: Int
-
   """Checks for equality with the object’s \`barId\` field."""
   barId: Int
+
+  """Checks for equality with the object’s \`fooId\` field."""
+  fooId: Int
 }
 
 """A connection to a list of \`Corge\` values."""
 type CorgesConnection {
-  """A list of \`Corge\` objects."""
-  nodes: [Corge]!
-
   """
   A list of edges which contains the \`Corge\` and cursor to aid in pagination.
   """
   edges: [CorgesEdge!]!
+
+  """A list of \`Corge\` objects."""
+  nodes: [Corge]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -230,11 +229,11 @@ type CorgesEdge {
 
 """Methods to use when ordering \`Corge\`."""
 enum CorgesOrderBy {
-  NATURAL
-  FOO_ID_ASC
-  FOO_ID_DESC
   BAR_ID_ASC
   BAR_ID_DESC
+  FOO_ID_ASC
+  FOO_ID_DESC
+  NATURAL
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
@@ -243,50 +242,24 @@ enum CorgesOrderBy {
 scalar Cursor
 
 """
-A point in time as described by the [ISO
-8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
+A point in time as described by the [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
 """
 scalar Datetime
 
 type Foo implements Node {
-  """
-  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  """
-  nodeId: ID!
-  id: Int!
-  name: String!
-
   """Reads and enables pagination through a set of \`Baz\`."""
   bazsByFooId(
-    """Only read the first \`n\` values of the set."""
-    first: Int
-
-    """Only read the last \`n\` values of the set."""
-    last: Int
-
-    """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
     """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    """The method to use when ordering \`Baz\`."""
-    orderBy: [BazsOrderBy!] = [PRIMARY_KEY_ASC]
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
     condition: BazCondition
-  ): BazsConnection!
 
-  """Reads and enables pagination through a set of \`Qux\`."""
-  quxesByFooId(
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -294,54 +267,76 @@ type Foo implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
 
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
-    """The method to use when ordering \`Qux\`."""
-    orderBy: [QuxesOrderBy!] = [PRIMARY_KEY_ASC]
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: QuxCondition
-  ): QuxesConnection!
+    """The method to use when ordering \`Baz\`."""
+    orderBy: [BazsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): BazsConnection!
 
   """Reads and enables pagination through a set of \`Corge\`."""
   corgesByFooId(
-    """Only read the first \`n\` values of the set."""
-    first: Int
-
-    """Only read the last \`n\` values of the set."""
-    last: Int
-
-    """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
     """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    """The method to use when ordering \`Corge\`."""
-    orderBy: [CorgesOrderBy!] = [PRIMARY_KEY_ASC]
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
     condition: CorgeCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Corge\`."""
+    orderBy: [CorgesOrderBy!] = [PRIMARY_KEY_ASC]
   ): CorgesConnection!
+  id: Int!
+  name: String!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+
+  """Reads and enables pagination through a set of \`Qux\`."""
+  quxesByFooId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: QuxCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Qux\`."""
+    orderBy: [QuxesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): QuxesConnection!
 }
 
 """
@@ -357,13 +352,13 @@ input FooCondition {
 
 """A connection to a list of \`Foo\` values."""
 type FoosConnection {
-  """A list of \`Foo\` objects."""
-  nodes: [Foo]!
-
   """
   A list of edges which contains the \`Foo\` and cursor to aid in pagination.
   """
   edges: [FoosEdge!]!
+
+  """A list of \`Foo\` objects."""
+  nodes: [Foo]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -383,55 +378,55 @@ type FoosEdge {
 
 """Methods to use when ordering \`Foo\`."""
 enum FoosOrderBy {
-  NATURAL
   ID_ASC
   ID_DESC
   NAME_ASC
   NAME_DESC
+  NATURAL
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
 
 type Membership implements Node {
+  createdAt: Datetime!
+
   """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   """
   nodeId: ID!
-  personId: Int!
-  teamId: Int!
-  createdAt: Datetime!
 
   """Reads a single \`Person\` that is related to this \`Membership\`."""
   personByPersonId: Person
+  personId: Int!
 
   """Reads a single \`Team\` that is related to this \`Membership\`."""
   teamByTeamId: Team
+  teamId: Int!
 }
 
 """
-A condition to be used against \`Membership\` object types. All fields are tested
-for equality and combined with a logical ‘and.’
+A condition to be used against \`Membership\` object types. All fields are tested for equality and combined with a logical ‘and.’
 """
 input MembershipCondition {
+  """Checks for equality with the object’s \`createdAt\` field."""
+  createdAt: Datetime
+
   """Checks for equality with the object’s \`personId\` field."""
   personId: Int
 
   """Checks for equality with the object’s \`teamId\` field."""
   teamId: Int
-
-  """Checks for equality with the object’s \`createdAt\` field."""
-  createdAt: Datetime
 }
 
 """A connection to a list of \`Membership\` values."""
 type MembershipsConnection {
-  """A list of \`Membership\` objects."""
-  nodes: [Membership]!
-
   """
   A list of edges which contains the \`Membership\` and cursor to aid in pagination.
   """
   edges: [MembershipsEdge!]!
+
+  """A list of \`Membership\` objects."""
+  nodes: [Membership]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -451,15 +446,15 @@ type MembershipsEdge {
 
 """Methods to use when ordering \`Membership\`."""
 enum MembershipsOrderBy {
+  CREATED_AT_ASC
+  CREATED_AT_DESC
   NATURAL
   PERSON_ID_ASC
   PERSON_ID_DESC
-  TEAM_ID_ASC
-  TEAM_ID_DESC
-  CREATED_AT_ASC
-  CREATED_AT_DESC
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
+  TEAM_ID_ASC
+  TEAM_ID_DESC
 }
 
 """An object with a globally unique \`ID\`."""
@@ -472,6 +467,9 @@ interface Node {
 
 """Information about pagination in a connection."""
 type PageInfo {
+  """When paginating forwards, the cursor to continue."""
+  endCursor: Cursor
+
   """When paginating forwards, are there more items?"""
   hasNextPage: Boolean!
 
@@ -480,20 +478,17 @@ type PageInfo {
 
   """When paginating backwards, the cursor to continue."""
   startCursor: Cursor
-
-  """When paginating forwards, the cursor to continue."""
-  endCursor: Cursor
 }
 
 """A connection to a list of \`Person\` values."""
 type PeopleConnection {
-  """A list of \`Person\` objects."""
-  nodes: [Person]!
-
   """
   A list of edges which contains the \`Person\` and cursor to aid in pagination.
   """
   edges: [PeopleEdge!]!
+
+  """A list of \`Person\` objects."""
+  nodes: [Person]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -513,9 +508,9 @@ type PeopleEdge {
 
 """Methods to use when ordering \`Person\`."""
 enum PeopleOrderBy {
-  NATURAL
   ID_ASC
   ID_DESC
+  NATURAL
   PERSON_NAME_ASC
   PERSON_NAME_DESC
   PRIMARY_KEY_ASC
@@ -523,44 +518,21 @@ enum PeopleOrderBy {
 }
 
 type Person implements Node {
-  """
-  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  """
-  nodeId: ID!
   id: Int!
-  personName: String!
 
   """Reads and enables pagination through a set of \`Membership\`."""
   membershipsByPersonId(
-    """Only read the first \`n\` values of the set."""
-    first: Int
-
-    """Only read the last \`n\` values of the set."""
-    last: Int
-
-    """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
     """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    """The method to use when ordering \`Membership\`."""
-    orderBy: [MembershipsOrderBy!] = [PRIMARY_KEY_ASC]
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
     condition: MembershipCondition
-  ): MembershipsConnection!
 
-  """Reads and enables pagination through a set of \`Team\`."""
-  teamsByMembershipPersonIdAndTeamId(
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -568,24 +540,46 @@ type Person implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
 
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
+    """The method to use when ordering \`Membership\`."""
+    orderBy: [MembershipsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): MembershipsConnection!
 
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  personName: String!
+
+  """Reads and enables pagination through a set of \`Team\`."""
+  teamsByMembershipPersonIdAndTeamId(
     """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    """The method to use when ordering \`Team\`."""
-    orderBy: [TeamsOrderBy!] = [PRIMARY_KEY_ASC]
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
     condition: TeamCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Team\`."""
+    orderBy: [TeamsOrderBy!] = [PRIMARY_KEY_ASC]
   ): PersonTeamsByMembershipPersonIdAndTeamIdManyToManyConnection!
 }
 
@@ -602,13 +596,13 @@ input PersonCondition {
 
 """A connection to a list of \`Team\` values, with data from \`Membership\`."""
 type PersonTeamsByMembershipPersonIdAndTeamIdManyToManyConnection {
-  """A list of \`Team\` objects."""
-  nodes: [Team]!
-
   """
   A list of edges which contains the \`Team\`, info from the \`Membership\`, and the cursor to aid in pagination.
   """
   edges: [PersonTeamsByMembershipPersonIdAndTeamIdManyToManyEdge!]!
+
+  """A list of \`Team\` objects."""
+  nodes: [Team]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -619,64 +613,30 @@ type PersonTeamsByMembershipPersonIdAndTeamIdManyToManyConnection {
 
 """A \`Team\` edge in the connection, with data from \`Membership\`."""
 type PersonTeamsByMembershipPersonIdAndTeamIdManyToManyEdge {
+  createdAt: Datetime!
+
   """A cursor for use in pagination."""
   cursor: Cursor
 
   """The \`Team\` at the end of the edge."""
   node: Team
-  createdAt: Datetime!
 }
 
 """The root query type which gives access points into the data universe."""
 type Query implements Node {
-  """
-  Exposes the root query type nested one level down. This is helpful for Relay 1
-  which can only query top level fields if they are in a particular form.
-  """
-  query: Query!
-
-  """
-  The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
-  """
-  nodeId: ID!
-
-  """Fetches an object given its globally unique \`ID\`."""
-  node(
-    """The globally unique \`ID\`."""
-    nodeId: ID!
-  ): Node
-
   """Reads and enables pagination through a set of \`Bar\`."""
   allBars(
-    """Only read the first \`n\` values of the set."""
-    first: Int
-
-    """Only read the last \`n\` values of the set."""
-    last: Int
-
-    """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
     """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    """The method to use when ordering \`Bar\`."""
-    orderBy: [BarsOrderBy!] = [PRIMARY_KEY_ASC]
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
     condition: BarCondition
-  ): BarsConnection
 
-  """Reads and enables pagination through a set of \`Baz\`."""
-  allBazs(
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -684,28 +644,27 @@ type Query implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
 
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
+    """The method to use when ordering \`Bar\`."""
+    orderBy: [BarsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): BarsConnection
 
+  """Reads and enables pagination through a set of \`Baz\`."""
+  allBazs(
     """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    """The method to use when ordering \`Baz\`."""
-    orderBy: [BazsOrderBy!] = [PRIMARY_KEY_ASC]
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
     condition: BazCondition
-  ): BazsConnection
 
-  """Reads and enables pagination through a set of \`Foo\`."""
-  allFoos(
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -713,28 +672,27 @@ type Query implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
 
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
+    """The method to use when ordering \`Baz\`."""
+    orderBy: [BazsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): BazsConnection
 
+  """Reads and enables pagination through a set of \`Foo\`."""
+  allFoos(
     """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    """The method to use when ordering \`Foo\`."""
-    orderBy: [FoosOrderBy!] = [PRIMARY_KEY_ASC]
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
     condition: FooCondition
-  ): FoosConnection
 
-  """Reads and enables pagination through a set of \`Membership\`."""
-  allMemberships(
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -742,28 +700,27 @@ type Query implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
 
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
+    """The method to use when ordering \`Foo\`."""
+    orderBy: [FoosOrderBy!] = [PRIMARY_KEY_ASC]
+  ): FoosConnection
 
+  """Reads and enables pagination through a set of \`Membership\`."""
+  allMemberships(
     """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    """The method to use when ordering \`Membership\`."""
-    orderBy: [MembershipsOrderBy!] = [PRIMARY_KEY_ASC]
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
     condition: MembershipCondition
-  ): MembershipsConnection
 
-  """Reads and enables pagination through a set of \`Person\`."""
-  allPeople(
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -771,28 +728,27 @@ type Query implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
 
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
+    """The method to use when ordering \`Membership\`."""
+    orderBy: [MembershipsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): MembershipsConnection
 
+  """Reads and enables pagination through a set of \`Person\`."""
+  allPeople(
     """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    """The method to use when ordering \`Person\`."""
-    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
     condition: PersonCondition
-  ): PeopleConnection
 
-  """Reads and enables pagination through a set of \`Team\`."""
-  allTeams(
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -800,57 +756,69 @@ type Query implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
 
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
+    """The method to use when ordering \`Person\`."""
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PeopleConnection
 
+  """Reads and enables pagination through a set of \`Team\`."""
+  allTeams(
     """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    """The method to use when ordering \`Team\`."""
-    orderBy: [TeamsOrderBy!] = [PRIMARY_KEY_ASC]
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
     condition: TeamCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Team\`."""
+    orderBy: [TeamsOrderBy!] = [PRIMARY_KEY_ASC]
   ): TeamsConnection
-  barById(id: Int!): Bar
-  bazByFooIdAndBarId(fooId: Int!, barId: Int!): Baz
-  corgeByFooIdAndBarId(fooId: Int!, barId: Int!): Corge
-  fooById(id: Int!): Foo
-  membershipByPersonIdAndTeamId(personId: Int!, teamId: Int!): Membership
-  personById(id: Int!): Person
-  quxByFooIdAndBarId(fooId: Int!, barId: Int!): Qux
-  teamById(id: Int!): Team
 
   """Reads a single \`Bar\` using its globally unique \`ID\`."""
   bar(
     """The globally unique \`ID\` to be used in selecting a single \`Bar\`."""
     nodeId: ID!
   ): Bar
+  barById(id: Int!): Bar
 
   """Reads a single \`Baz\` using its globally unique \`ID\`."""
   baz(
     """The globally unique \`ID\` to be used in selecting a single \`Baz\`."""
     nodeId: ID!
   ): Baz
+  bazByFooIdAndBarId(barId: Int!, fooId: Int!): Baz
 
   """Reads a single \`Corge\` using its globally unique \`ID\`."""
   corge(
     """The globally unique \`ID\` to be used in selecting a single \`Corge\`."""
     nodeId: ID!
   ): Corge
+  corgeByFooIdAndBarId(barId: Int!, fooId: Int!): Corge
 
   """Reads a single \`Foo\` using its globally unique \`ID\`."""
   foo(
     """The globally unique \`ID\` to be used in selecting a single \`Foo\`."""
     nodeId: ID!
   ): Foo
+  fooById(id: Int!): Foo
 
   """Reads a single \`Membership\` using its globally unique \`ID\`."""
   membership(
@@ -859,61 +827,81 @@ type Query implements Node {
     """
     nodeId: ID!
   ): Membership
+  membershipByPersonIdAndTeamId(personId: Int!, teamId: Int!): Membership
+
+  """Fetches an object given its globally unique \`ID\`."""
+  node(
+    """The globally unique \`ID\`."""
+    nodeId: ID!
+  ): Node
+
+  """
+  The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
+  """
+  nodeId: ID!
 
   """Reads a single \`Person\` using its globally unique \`ID\`."""
   person(
     """The globally unique \`ID\` to be used in selecting a single \`Person\`."""
     nodeId: ID!
   ): Person
+  personById(id: Int!): Person
+
+  """
+  Exposes the root query type nested one level down. This is helpful for Relay 1 which can only query top level fields if they are in a particular form.
+  """
+  query: Query!
 
   """Reads a single \`Qux\` using its globally unique \`ID\`."""
   qux(
     """The globally unique \`ID\` to be used in selecting a single \`Qux\`."""
     nodeId: ID!
   ): Qux
+  quxByFooIdAndBarId(barId: Int!, fooId: Int!): Qux
 
   """Reads a single \`Team\` using its globally unique \`ID\`."""
   team(
     """The globally unique \`ID\` to be used in selecting a single \`Team\`."""
     nodeId: ID!
   ): Team
+  teamById(id: Int!): Team
 }
 
 type Qux implements Node {
-  """
-  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  """
-  nodeId: ID!
-  fooId: Int!
+  """Reads a single \`Bar\` that is related to this \`Qux\`."""
+  barByBarId: Bar
   barId: Int!
 
   """Reads a single \`Foo\` that is related to this \`Qux\`."""
   fooByFooId: Foo
+  fooId: Int!
 
-  """Reads a single \`Bar\` that is related to this \`Qux\`."""
-  barByBarId: Bar
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
 }
 
 """
 A condition to be used against \`Qux\` object types. All fields are tested for equality and combined with a logical ‘and.’
 """
 input QuxCondition {
-  """Checks for equality with the object’s \`fooId\` field."""
-  fooId: Int
-
   """Checks for equality with the object’s \`barId\` field."""
   barId: Int
+
+  """Checks for equality with the object’s \`fooId\` field."""
+  fooId: Int
 }
 
 """A connection to a list of \`Qux\` values."""
 type QuxesConnection {
-  """A list of \`Qux\` objects."""
-  nodes: [Qux]!
-
   """
   A list of edges which contains the \`Qux\` and cursor to aid in pagination.
   """
   edges: [QuxesEdge!]!
+
+  """A list of \`Qux\` objects."""
+  nodes: [Qux]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -933,80 +921,79 @@ type QuxesEdge {
 
 """Methods to use when ordering \`Qux\`."""
 enum QuxesOrderBy {
-  NATURAL
-  FOO_ID_ASC
-  FOO_ID_DESC
   BAR_ID_ASC
   BAR_ID_DESC
+  FOO_ID_ASC
+  FOO_ID_DESC
+  NATURAL
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
 }
 
 type Team implements Node {
-  """
-  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  """
-  nodeId: ID!
   id: Int!
-  teamName: String!
-
-  """Reads and enables pagination through a set of \`Membership\`."""
-  membershipsByTeamId(
-    """Only read the first \`n\` values of the set."""
-    first: Int
-
-    """Only read the last \`n\` values of the set."""
-    last: Int
-
-    """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
-    """The method to use when ordering \`Membership\`."""
-    orderBy: [MembershipsOrderBy!] = [PRIMARY_KEY_ASC]
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: MembershipCondition
-  ): MembershipsConnection!
 
   """Reads and enables pagination through a set of \`Person\`."""
   members(
-    """Only read the first \`n\` values of the set."""
-    first: Int
-
-    """Only read the last \`n\` values of the set."""
-    last: Int
-
-    """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
     """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    """The method to use when ordering \`Person\`."""
-    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
     condition: PersonCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Person\`."""
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
   ): TeamMembersManyToManyConnection!
+
+  """Reads and enables pagination through a set of \`Membership\`."""
+  membershipsByTeamId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: MembershipCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Membership\`."""
+    orderBy: [MembershipsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): MembershipsConnection!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  teamName: String!
 }
 
 """
@@ -1024,13 +1011,13 @@ input TeamCondition {
 A connection to a list of \`Person\` values, with data from \`Membership\`.
 """
 type TeamMembersManyToManyConnection {
-  """A list of \`Person\` objects."""
-  nodes: [Person]!
-
   """
   A list of edges which contains the \`Person\`, info from the \`Membership\`, and the cursor to aid in pagination.
   """
   edges: [TeamMembersManyToManyEdge!]!
+
+  """A list of \`Person\` objects."""
+  nodes: [Person]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -1041,23 +1028,24 @@ type TeamMembersManyToManyConnection {
 
 """A \`Person\` edge in the connection, with data from \`Membership\`."""
 type TeamMembersManyToManyEdge {
+  createdAt: Datetime!
+
   """A cursor for use in pagination."""
   cursor: Cursor
 
   """The \`Person\` at the end of the edge."""
   node: Person
-  createdAt: Datetime!
 }
 
 """A connection to a list of \`Team\` values."""
 type TeamsConnection {
-  """A list of \`Team\` objects."""
-  nodes: [Team]!
-
   """
   A list of edges which contains the \`Team\` and cursor to aid in pagination.
   """
   edges: [TeamsEdge!]!
+
+  """A list of \`Team\` objects."""
+  nodes: [Team]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -1077,13 +1065,13 @@ type TeamsEdge {
 
 """Methods to use when ordering \`Team\`."""
 enum TeamsOrderBy {
-  NATURAL
   ID_ASC
   ID_DESC
-  TEAM_NAME_ASC
-  TEAM_NAME_DESC
+  NATURAL
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
+  TEAM_NAME_ASC
+  TEAM_NAME_DESC
 }
 "
 `;

--- a/__tests__/integration/schema/__snapshots__/t.test.js.snap
+++ b/__tests__/integration/schema/__snapshots__/t.test.js.snap
@@ -5,59 +5,58 @@ exports[`prints a schema with the many-to-many plugin 1`] = `
 scalar Cursor
 
 """
-A point in time as described by the [ISO
-8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
+A point in time as described by the [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
 """
 scalar Datetime
 
 type Membership implements Node {
+  endAt: Datetime
+  id: Int!
+
   """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   """
   nodeId: ID!
-  id: Int!
-  personId: Int!
-  teamId: Int!
-  startAt: Datetime!
-  endAt: Datetime
 
   """Reads a single \`Person\` that is related to this \`Membership\`."""
   personByPersonId: Person
+  personId: Int!
+  startAt: Datetime!
 
   """Reads a single \`Team\` that is related to this \`Membership\`."""
   teamByTeamId: Team
+  teamId: Int!
 }
 
 """
-A condition to be used against \`Membership\` object types. All fields are tested
-for equality and combined with a logical ‘and.’
+A condition to be used against \`Membership\` object types. All fields are tested for equality and combined with a logical ‘and.’
 """
 input MembershipCondition {
+  """Checks for equality with the object’s \`endAt\` field."""
+  endAt: Datetime
+
   """Checks for equality with the object’s \`id\` field."""
   id: Int
 
   """Checks for equality with the object’s \`personId\` field."""
   personId: Int
 
-  """Checks for equality with the object’s \`teamId\` field."""
-  teamId: Int
-
   """Checks for equality with the object’s \`startAt\` field."""
   startAt: Datetime
 
-  """Checks for equality with the object’s \`endAt\` field."""
-  endAt: Datetime
+  """Checks for equality with the object’s \`teamId\` field."""
+  teamId: Int
 }
 
 """A connection to a list of \`Membership\` values."""
 type MembershipsConnection {
-  """A list of \`Membership\` objects."""
-  nodes: [Membership]!
-
   """
   A list of edges which contains the \`Membership\` and cursor to aid in pagination.
   """
   edges: [MembershipsEdge!]!
+
+  """A list of \`Membership\` objects."""
+  nodes: [Membership]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -77,19 +76,19 @@ type MembershipsEdge {
 
 """Methods to use when ordering \`Membership\`."""
 enum MembershipsOrderBy {
-  NATURAL
-  ID_ASC
-  ID_DESC
-  PERSON_ID_ASC
-  PERSON_ID_DESC
-  TEAM_ID_ASC
-  TEAM_ID_DESC
-  START_AT_ASC
-  START_AT_DESC
   END_AT_ASC
   END_AT_DESC
+  ID_ASC
+  ID_DESC
+  NATURAL
+  PERSON_ID_ASC
+  PERSON_ID_DESC
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
+  START_AT_ASC
+  START_AT_DESC
+  TEAM_ID_ASC
+  TEAM_ID_DESC
 }
 
 """An object with a globally unique \`ID\`."""
@@ -102,6 +101,9 @@ interface Node {
 
 """Information about pagination in a connection."""
 type PageInfo {
+  """When paginating forwards, the cursor to continue."""
+  endCursor: Cursor
+
   """When paginating forwards, are there more items?"""
   hasNextPage: Boolean!
 
@@ -110,20 +112,17 @@ type PageInfo {
 
   """When paginating backwards, the cursor to continue."""
   startCursor: Cursor
-
-  """When paginating forwards, the cursor to continue."""
-  endCursor: Cursor
 }
 
 """A connection to a list of \`Person\` values."""
 type PeopleConnection {
-  """A list of \`Person\` objects."""
-  nodes: [Person]!
-
   """
   A list of edges which contains the \`Person\` and cursor to aid in pagination.
   """
   edges: [PeopleEdge!]!
+
+  """A list of \`Person\` objects."""
+  nodes: [Person]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -143,9 +142,9 @@ type PeopleEdge {
 
 """Methods to use when ordering \`Person\`."""
 enum PeopleOrderBy {
-  NATURAL
   ID_ASC
   ID_DESC
+  NATURAL
   PERSON_NAME_ASC
   PERSON_NAME_DESC
   PRIMARY_KEY_ASC
@@ -153,44 +152,21 @@ enum PeopleOrderBy {
 }
 
 type Person implements Node {
-  """
-  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  """
-  nodeId: ID!
   id: Int!
-  personName: String!
 
   """Reads and enables pagination through a set of \`Membership\`."""
   membershipsByPersonId(
-    """Only read the first \`n\` values of the set."""
-    first: Int
-
-    """Only read the last \`n\` values of the set."""
-    last: Int
-
-    """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
     """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    """The method to use when ordering \`Membership\`."""
-    orderBy: [MembershipsOrderBy!] = [PRIMARY_KEY_ASC]
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
     condition: MembershipCondition
-  ): MembershipsConnection!
 
-  """Reads and enables pagination through a set of \`Team\`."""
-  teamsByMembershipPersonIdAndTeamId(
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -198,24 +174,46 @@ type Person implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
 
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
+    """The method to use when ordering \`Membership\`."""
+    orderBy: [MembershipsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): MembershipsConnection!
 
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  personName: String!
+
+  """Reads and enables pagination through a set of \`Team\`."""
+  teamsByMembershipPersonIdAndTeamId(
     """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    """The method to use when ordering \`Team\`."""
-    orderBy: [TeamsOrderBy!] = [PRIMARY_KEY_ASC]
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
     condition: TeamCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Team\`."""
+    orderBy: [TeamsOrderBy!] = [PRIMARY_KEY_ASC]
   ): PersonTeamsByMembershipPersonIdAndTeamIdManyToManyConnection!
 }
 
@@ -232,13 +230,13 @@ input PersonCondition {
 
 """A connection to a list of \`Team\` values, with data from \`Membership\`."""
 type PersonTeamsByMembershipPersonIdAndTeamIdManyToManyConnection {
-  """A list of \`Team\` objects."""
-  nodes: [Team]!
-
   """
   A list of edges which contains the \`Team\`, info from the \`Membership\`, and the cursor to aid in pagination.
   """
   edges: [PersonTeamsByMembershipPersonIdAndTeamIdManyToManyEdge!]!
+
+  """A list of \`Team\` objects."""
+  nodes: [Team]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -252,11 +250,19 @@ type PersonTeamsByMembershipPersonIdAndTeamIdManyToManyEdge {
   """A cursor for use in pagination."""
   cursor: Cursor
 
-  """The \`Team\` at the end of the edge."""
-  node: Team
-
   """Reads and enables pagination through a set of \`Membership\`."""
   membershipsByTeamId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: MembershipCondition
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -264,77 +270,33 @@ type PersonTeamsByMembershipPersonIdAndTeamIdManyToManyEdge {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
 
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
     """The method to use when ordering \`Membership\`."""
     orderBy: [MembershipsOrderBy!] = [PRIMARY_KEY_ASC]
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: MembershipCondition
   ): MembershipsConnection!
+
+  """The \`Team\` at the end of the edge."""
+  node: Team
 }
 
 """The root query type which gives access points into the data universe."""
 type Query implements Node {
-  """
-  Exposes the root query type nested one level down. This is helpful for Relay 1
-  which can only query top level fields if they are in a particular form.
-  """
-  query: Query!
-
-  """
-  The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
-  """
-  nodeId: ID!
-
-  """Fetches an object given its globally unique \`ID\`."""
-  node(
-    """The globally unique \`ID\`."""
-    nodeId: ID!
-  ): Node
-
   """Reads and enables pagination through a set of \`Membership\`."""
   allMemberships(
-    """Only read the first \`n\` values of the set."""
-    first: Int
-
-    """Only read the last \`n\` values of the set."""
-    last: Int
-
-    """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
     """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    """The method to use when ordering \`Membership\`."""
-    orderBy: [MembershipsOrderBy!] = [PRIMARY_KEY_ASC]
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
     condition: MembershipCondition
-  ): MembershipsConnection
 
-  """Reads and enables pagination through a set of \`Person\`."""
-  allPeople(
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -342,28 +304,27 @@ type Query implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
 
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
+    """The method to use when ordering \`Membership\`."""
+    orderBy: [MembershipsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): MembershipsConnection
 
+  """Reads and enables pagination through a set of \`Person\`."""
+  allPeople(
     """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    """The method to use when ordering \`Person\`."""
-    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
     condition: PersonCondition
-  ): PeopleConnection
 
-  """Reads and enables pagination through a set of \`Team\`."""
-  allTeams(
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -371,28 +332,41 @@ type Query implements Node {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
 
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
+    """The method to use when ordering \`Person\`."""
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PeopleConnection
 
+  """Reads and enables pagination through a set of \`Team\`."""
+  allTeams(
     """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    """The method to use when ordering \`Team\`."""
-    orderBy: [TeamsOrderBy!] = [PRIMARY_KEY_ASC]
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
     condition: TeamCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Team\`."""
+    orderBy: [TeamsOrderBy!] = [PRIMARY_KEY_ASC]
   ): TeamsConnection
-  membershipById(id: Int!): Membership
-  personById(id: Int!): Person
-  teamById(id: Int!): Team
 
   """Reads a single \`Membership\` using its globally unique \`ID\`."""
   membership(
@@ -401,85 +375,103 @@ type Query implements Node {
     """
     nodeId: ID!
   ): Membership
+  membershipById(id: Int!): Membership
+
+  """Fetches an object given its globally unique \`ID\`."""
+  node(
+    """The globally unique \`ID\`."""
+    nodeId: ID!
+  ): Node
+
+  """
+  The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
+  """
+  nodeId: ID!
 
   """Reads a single \`Person\` using its globally unique \`ID\`."""
   person(
     """The globally unique \`ID\` to be used in selecting a single \`Person\`."""
     nodeId: ID!
   ): Person
+  personById(id: Int!): Person
+
+  """
+  Exposes the root query type nested one level down. This is helpful for Relay 1 which can only query top level fields if they are in a particular form.
+  """
+  query: Query!
 
   """Reads a single \`Team\` using its globally unique \`ID\`."""
   team(
     """The globally unique \`ID\` to be used in selecting a single \`Team\`."""
     nodeId: ID!
   ): Team
+  teamById(id: Int!): Team
 }
 
 type Team implements Node {
-  """
-  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
-  """
-  nodeId: ID!
   id: Int!
-  teamName: String!
-
-  """Reads and enables pagination through a set of \`Membership\`."""
-  membershipsByTeamId(
-    """Only read the first \`n\` values of the set."""
-    first: Int
-
-    """Only read the last \`n\` values of the set."""
-    last: Int
-
-    """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
-    """The method to use when ordering \`Membership\`."""
-    orderBy: [MembershipsOrderBy!] = [PRIMARY_KEY_ASC]
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: MembershipCondition
-  ): MembershipsConnection!
 
   """Reads and enables pagination through a set of \`Person\`."""
   members(
-    """Only read the first \`n\` values of the set."""
-    first: Int
-
-    """Only read the last \`n\` values of the set."""
-    last: Int
-
-    """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
-    """
-    offset: Int
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
     """Read all values in the set after (below) this cursor."""
     after: Cursor
 
-    """The method to use when ordering \`Person\`."""
-    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
 
     """
     A condition to be used in determining which values should be returned by the collection.
     """
     condition: PersonCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Person\`."""
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
   ): TeamMembersManyToManyConnection!
+
+  """Reads and enables pagination through a set of \`Membership\`."""
+  membershipsByTeamId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: MembershipCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Membership\`."""
+    orderBy: [MembershipsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): MembershipsConnection!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  teamName: String!
 }
 
 """
@@ -497,13 +489,13 @@ input TeamCondition {
 A connection to a list of \`Person\` values, with data from \`Membership\`.
 """
 type TeamMembersManyToManyConnection {
-  """A list of \`Person\` objects."""
-  nodes: [Person]!
-
   """
   A list of edges which contains the \`Person\`, info from the \`Membership\`, and the cursor to aid in pagination.
   """
   edges: [TeamMembersManyToManyEdge!]!
+
+  """A list of \`Person\` objects."""
+  nodes: [Person]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -517,11 +509,19 @@ type TeamMembersManyToManyEdge {
   """A cursor for use in pagination."""
   cursor: Cursor
 
-  """The \`Person\` at the end of the edge."""
-  node: Person
-
   """Reads and enables pagination through a set of \`Membership\`."""
   membershipsByPersonId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: MembershipCondition
+
     """Only read the first \`n\` values of the set."""
     first: Int
 
@@ -529,36 +529,27 @@ type TeamMembersManyToManyEdge {
     last: Int
 
     """
-    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
-    based pagination. May not be used with \`last\`.
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor based pagination. May not be used with \`last\`.
     """
     offset: Int
 
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
     """The method to use when ordering \`Membership\`."""
     orderBy: [MembershipsOrderBy!] = [PRIMARY_KEY_ASC]
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: MembershipCondition
   ): MembershipsConnection!
+
+  """The \`Person\` at the end of the edge."""
+  node: Person
 }
 
 """A connection to a list of \`Team\` values."""
 type TeamsConnection {
-  """A list of \`Team\` objects."""
-  nodes: [Team]!
-
   """
   A list of edges which contains the \`Team\` and cursor to aid in pagination.
   """
   edges: [TeamsEdge!]!
+
+  """A list of \`Team\` objects."""
+  nodes: [Team]!
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
@@ -578,13 +569,13 @@ type TeamsEdge {
 
 """Methods to use when ordering \`Team\`."""
 enum TeamsOrderBy {
-  NATURAL
   ID_ASC
   ID_DESC
-  TEAM_NAME_ASC
-  TEAM_NAME_DESC
+  NATURAL
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
+  TEAM_NAME_ASC
+  TEAM_NAME_DESC
 }
 "
 `;

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "eslint-config-prettier": "8.5.0",
     "eslint-plugin-jest": "27.1.6",
     "eslint-plugin-prettier": "4.2.1",
-    "graphql": "^14.7.0",
+    "graphql": "15.8.0",
     "jest": "29.3.1",
     "pg": "8.8.0",
     "postgraphile-core": "4.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1576,12 +1576,10 @@ graphql-parse-resolve-info@4.5.0:
   dependencies:
     debug "^4.1.1"
 
-graphql@^14.7.0:
-  version "14.7.0"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.7.0.tgz#7fa79a80a69be4a31c27dda824dc04dac2035a72"
-  integrity sha512-l0xWZpoPKpppFzMfvVyFmp9vLN7w/ZZJPefUicMCepfJeQ8sMcztloGYY9DfjVPo6tIUDzU5Hw3MUbIjj9AVVA==
-  dependencies:
-    iterall "^1.2.2"
+graphql@15.8.0:
+  version "15.8.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.8.0.tgz#33410e96b012fa3bdb1091cc99a94769db212b38"
+  integrity sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==
 
 has-flag@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
- Update `graphql` to `15.8.0`
- Replace custom schema sorting helper with `lexicographicSortSchema` from `graphql/utilities`
- Update test snapshots to match the order produced by `lexicographicSortSchema`