### PR TITLE
Make some field additions recoverable

### DIFF
--- a/__tests__/__snapshots__/queries.test.js.snap
+++ b/__tests__/__snapshots__/queries.test.js.snap
@@ -1060,3 +1060,245 @@ exports[`schema=t query=many-to-many.graphql 1`] = `
   },
 }
 `;
+
+exports[`schema=u query=edge-fields.graphql 1`] = `
+{
+  "data": {
+    "allEntities": {
+      "nodes": [
+        {
+          "memberOf": {
+            "edges": [
+              {
+                "memberships": {
+                  "nodes": [
+                    {
+                      "endAt": null,
+                      "startAt": "2018-01-01T08:00:00.000000-0400",
+                    },
+                  ],
+                },
+                "node": {
+                  "name": "Team1",
+                },
+              },
+              {
+                "memberships": {
+                  "nodes": [
+                    {
+                      "endAt": "2018-01-03T08:00:00.000000-0400",
+                      "startAt": "2018-01-02T08:00:00.000000-0400",
+                    },
+                    {
+                      "endAt": "2018-01-05T08:00:00.000000-0400",
+                      "startAt": "2018-01-04T08:00:00.000000-0400",
+                    },
+                  ],
+                },
+                "node": {
+                  "name": "Team2",
+                },
+              },
+            ],
+          },
+          "members": {
+            "edges": [],
+          },
+          "name": "Person1",
+        },
+        {
+          "memberOf": {
+            "edges": [
+              {
+                "memberships": {
+                  "nodes": [
+                    {
+                      "endAt": null,
+                      "startAt": "2018-01-03T08:00:00.000000-0400",
+                    },
+                  ],
+                },
+                "node": {
+                  "name": "Team1",
+                },
+              },
+            ],
+          },
+          "members": {
+            "edges": [],
+          },
+          "name": "Person2",
+        },
+        {
+          "memberOf": {
+            "edges": [],
+          },
+          "members": {
+            "edges": [],
+          },
+          "name": "Person3",
+        },
+        {
+          "memberOf": {
+            "edges": [],
+          },
+          "members": {
+            "edges": [
+              {
+                "memberships": {
+                  "nodes": [
+                    {
+                      "endAt": null,
+                      "startAt": "2018-01-01T08:00:00.000000-0400",
+                    },
+                  ],
+                },
+                "node": {
+                  "name": "Person1",
+                },
+              },
+              {
+                "memberships": {
+                  "nodes": [
+                    {
+                      "endAt": null,
+                      "startAt": "2018-01-03T08:00:00.000000-0400",
+                    },
+                  ],
+                },
+                "node": {
+                  "name": "Person2",
+                },
+              },
+            ],
+          },
+          "name": "Team1",
+        },
+        {
+          "memberOf": {
+            "edges": [],
+          },
+          "members": {
+            "edges": [
+              {
+                "memberships": {
+                  "nodes": [
+                    {
+                      "endAt": "2018-01-03T08:00:00.000000-0400",
+                      "startAt": "2018-01-02T08:00:00.000000-0400",
+                    },
+                    {
+                      "endAt": "2018-01-05T08:00:00.000000-0400",
+                      "startAt": "2018-01-04T08:00:00.000000-0400",
+                    },
+                  ],
+                },
+                "node": {
+                  "name": "Person1",
+                },
+              },
+            ],
+          },
+          "name": "Team2",
+        },
+        {
+          "memberOf": {
+            "edges": [],
+          },
+          "members": {
+            "edges": [],
+          },
+          "name": "Team3",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`schema=u query=many-to-many.graphql 1`] = `
+{
+  "data": {
+    "allEntities": {
+      "nodes": [
+        {
+          "memberOf": {
+            "nodes": [
+              {
+                "name": "Team1",
+              },
+              {
+                "name": "Team2",
+              },
+            ],
+          },
+          "members": {
+            "nodes": [],
+          },
+          "name": "Person1",
+        },
+        {
+          "memberOf": {
+            "nodes": [
+              {
+                "name": "Team1",
+              },
+            ],
+          },
+          "members": {
+            "nodes": [],
+          },
+          "name": "Person2",
+        },
+        {
+          "memberOf": {
+            "nodes": [],
+          },
+          "members": {
+            "nodes": [],
+          },
+          "name": "Person3",
+        },
+        {
+          "memberOf": {
+            "nodes": [],
+          },
+          "members": {
+            "nodes": [
+              {
+                "name": "Person1",
+              },
+              {
+                "name": "Person2",
+              },
+            ],
+          },
+          "name": "Team1",
+        },
+        {
+          "memberOf": {
+            "nodes": [],
+          },
+          "members": {
+            "nodes": [
+              {
+                "name": "Person1",
+              },
+            ],
+          },
+          "name": "Team2",
+        },
+        {
+          "memberOf": {
+            "nodes": [],
+          },
+          "members": {
+            "nodes": [],
+          },
+          "name": "Team3",
+        },
+      ],
+    },
+  },
+}
+`;

--- a/__tests__/schemas/u/data.sql
+++ b/__tests__/schemas/u/data.sql
@@ -1,0 +1,20 @@
+insert into u.entity (id, name) values
+  (1, 'Person1'),
+  (2, 'Person2'),
+  (3, 'Person3'),
+  (4, 'Team1'),
+  (5, 'Team2'),
+  (6, 'Team3');
+
+insert into u.membership (member_id, entity_id, start_at, end_at) values
+  (1, 4, '2018-01-01T12:00:00Z', null),
+  (1, 5, '2018-01-02T12:00:00Z', '2018-01-03T12:00:00Z'),
+  (1, 5, '2018-01-04T12:00:00Z', '2018-01-05T12:00:00Z'),
+  (2, 4, '2018-01-03T12:00:00Z', null);
+
+-- Person1: [Team1,Team2]
+-- Person2: [Team1]
+-- Person3: []
+-- Team1: [Person1,Person2]
+-- Team2: [Person1]
+-- Team3: []

--- a/__tests__/schemas/u/fixtures/queries/edge-fields.graphql
+++ b/__tests__/schemas/u/fixtures/queries/edge-fields.graphql
@@ -1,0 +1,33 @@
+{
+  allEntities {
+    nodes {
+      name
+      memberOf: entitiesByMembershipMemberIdAndEntityId {
+        edges {
+          node {
+            name
+          }
+          memberships: membershipsByEntityId {
+            nodes {
+              startAt
+              endAt
+            }
+          }
+        }
+      }
+      members: entitiesByMembershipEntityIdAndMemberId {
+        edges {
+          node {
+            name
+          }
+          memberships: membershipsByMemberId {
+            nodes {
+              startAt
+              endAt
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/__tests__/schemas/u/fixtures/queries/many-to-many.graphql
+++ b/__tests__/schemas/u/fixtures/queries/many-to-many.graphql
@@ -1,0 +1,17 @@
+query {
+  allEntities {
+    nodes {
+      name
+      memberOf: entitiesByMembershipMemberIdAndEntityId {
+        nodes {
+          name
+        }
+      }
+      members: entitiesByMembershipEntityIdAndMemberId {
+        nodes {
+          name
+        }
+      }
+    }
+  }
+}

--- a/__tests__/schemas/u/schema.sql
+++ b/__tests__/schemas/u/schema.sql
@@ -1,0 +1,19 @@
+drop schema if exists u cascade;
+
+create schema u;
+
+create table u.entity (
+  id serial primary key,
+  name text not null
+);
+
+create table u.membership (
+  id serial primary key,
+  member_id int not null constraint membership_member_id_fkey references u.entity (id),
+  entity_id int not null constraint membership_entity_id_fkey references u.entity (id),
+  start_at timestamptz not null,
+  end_at timestamptz
+);
+
+create index on u.membership(member_id);
+create index on u.membership(entity_id);

--- a/src/PgManyToManyRelationEdgeTablePlugin.ts
+++ b/src/PgManyToManyRelationEdgeTablePlugin.ts
@@ -154,7 +154,7 @@ field to the edges where all of the join records can be traversed.`,
                             new GraphQLNonNull(JunctionTableType!)
                           )
                         ),
-                    args: {},
+                    args: Object.create(null),
                     plan(
                       $edge: EdgeStep<
                         any,

--- a/src/PgManyToManyRelationInflectionPlugin.ts
+++ b/src/PgManyToManyRelationInflectionPlugin.ts
@@ -51,7 +51,7 @@ export const PgManyToManyRelationInflectionPlugin: GraphileConfig.Plugin = {
           typeof junctionRightRelation.extensions?.tags.manyToManyFieldName ===
           "string"
         ) {
-          return junctionRightRelation.extensions?.tags.manyToManyFieldName;
+          return junctionRightRelation.extensions.tags.manyToManyFieldName;
         }
         return this.camelCase(
           `${this.pluralize(

--- a/src/PgManyToManyRelationPlugin.ts
+++ b/src/PgManyToManyRelationPlugin.ts
@@ -142,7 +142,7 @@ export const PgManyToManyRelationPlugin: GraphileConfig.Plugin = {
                                     new GraphQLNonNull(RightTableType!)
                                   )
                                 ),
-                            args: {},
+                            args: Object.create(null),
                             plan(
                               $left: PgSelectSingleStep<any, any, any, any>
                             ) {

--- a/src/PgManyToManyRelationPlugin.ts
+++ b/src/PgManyToManyRelationPlugin.ts
@@ -62,186 +62,201 @@ export const PgManyToManyRelationPlugin: GraphileConfig.Plugin = {
         const relationships = manyToManyRelationships(leftTable, build);
         return extend(
           fields,
-          relationships.reduce((memo, relationship) => {
-            const {
-              leftTable,
-              leftRelationName,
-              junctionTable,
-              rightRelationName,
-              rightTable,
-              allowsMultipleEdgesToNode,
-            } = relationship;
-            const RightTableType = build.getGraphQLTypeByPgCodec(
-              rightTable.codec,
-              "output"
-            ) as GraphQLObjectType | null;
-            if (!RightTableType) {
-              throw new Error(
-                `Could not determine output type for table ${rightTable.name}`
-              );
-            }
-            const leftTableTypeName = inflection.tableType(leftTable.codec);
-            const connectionTypeName = inflection.manyToManyRelationConnection({
-              ...relationship,
-              leftTableTypeName,
-            });
-            const RightTableConnectionType = build.getTypeByName(
-              connectionTypeName
-            ) as GraphQLObjectType | null;
-            if (!RightTableConnectionType) {
-              throw new Error(
-                `Could not find connection type for table ${rightTable.name}`
-              );
-            }
+          relationships.reduce(
+            (memo, relationship) =>
+              build.recoverable(memo, () => {
+                const {
+                  leftTable,
+                  leftRelationName,
+                  junctionTable,
+                  rightRelationName,
+                  rightTable,
+                  allowsMultipleEdgesToNode,
+                } = relationship;
+                const RightTableType = build.getGraphQLTypeByPgCodec(
+                  rightTable.codec,
+                  "output"
+                ) as GraphQLObjectType | null;
+                if (!RightTableType) {
+                  throw new Error(
+                    `Could not determine output type for table ${rightTable.name}`
+                  );
+                }
+                const leftTableTypeName = inflection.tableType(leftTable.codec);
+                const connectionTypeName =
+                  inflection.manyToManyRelationConnection({
+                    ...relationship,
+                    leftTableTypeName,
+                  });
+                const RightTableConnectionType = build.getTypeByName(
+                  connectionTypeName
+                ) as GraphQLObjectType | null;
+                if (!RightTableConnectionType) {
+                  throw new Error(
+                    `Could not find connection type for table ${rightTable.name}`
+                  );
+                }
 
-            const leftJunctionColumnNames =
-              leftTable.getRelation(leftRelationName).remoteColumns;
-            const leftJunctionColumnCodecs = leftJunctionColumnNames.map(
-              (colName) => junctionTable.codec.columns[colName].codec
-            );
-            const rightJunctionColumnNames =
-              junctionTable.getRelation(rightRelationName).localColumns;
-            const rightJunctionColumnCodecs = rightJunctionColumnNames.map(
-              (colName) => junctionTable.codec.columns[colName].codec
-            );
-            const rightTableRelationColumnNames =
-              junctionTable.getRelation(rightRelationName).remoteColumns;
+                const leftJunctionColumnNames =
+                  leftTable.getRelation(leftRelationName).remoteColumns;
+                const leftJunctionColumnCodecs = leftJunctionColumnNames.map(
+                  (colName) => junctionTable.codec.columns[colName].codec
+                );
+                const rightJunctionColumnNames =
+                  junctionTable.getRelation(rightRelationName).localColumns;
+                const rightJunctionColumnCodecs = rightJunctionColumnNames.map(
+                  (colName) => junctionTable.codec.columns[colName].codec
+                );
+                const rightTableRelationColumnNames =
+                  junctionTable.getRelation(rightRelationName).remoteColumns;
 
-            // TODO: throw an error if localColumns or remoteColumns involve
-            // `via` or `expression` - we only want pure column relations.
+                // TODO: throw an error if localColumns or remoteColumns involve
+                // `via` or `expression` - we only want pure column relations.
 
-            function makeFields(isConnection: boolean) {
-              const manyRelationFieldName = isConnection
-                ? inflection.manyToManyRelationByKeys(relationship)
-                : inflection.manyToManyRelationByKeysSimple(relationship);
+                function makeFields(isConnection: boolean) {
+                  const manyRelationFieldName = isConnection
+                    ? inflection.manyToManyRelationByKeys(relationship)
+                    : inflection.manyToManyRelationByKeysSimple(relationship);
 
-              memo = extend(
-                memo,
-                {
-                  [manyRelationFieldName]: fieldWithHooks(
-                    {
-                      fieldName: manyRelationFieldName,
-                      pgSource: rightTable,
-                      isPgFieldConnection: isConnection,
-                      isPgFieldSimpleCollection: !isConnection,
-                      isPgManyToManyRelationField: true,
-                      pgManyToManyRightTable: rightTable,
-                    },
-                    () => ({
-                      description: `Reads and enables pagination through a set of \`${
-                        RightTableType!.name
-                      }\`.`,
-                      type: isConnection
-                        ? new GraphQLNonNull(RightTableConnectionType!)
-                        : new GraphQLNonNull(
-                            new GraphQLList(new GraphQLNonNull(RightTableType!))
-                          ),
-                      args: {},
-                      plan($left: PgSelectSingleStep<any, any, any, any>) {
-                        const $junctions = $left.manyRelation(leftRelationName);
-                        // Fetch the identifiers and the return the relevant
-                        // rightTable entries for them.
-                        const $rightIdentifiers = each(
-                          $junctions,
-                          ($junction) => {
-                            const spec = Object.create(null);
-
-                            for (const colName of leftJunctionColumnNames) {
-                              spec[colName] = (
-                                $junction as PgSelectSingleStep<
-                                  any,
-                                  any,
-                                  any,
-                                  any
-                                >
-                              ).get(colName);
-                            }
-                            for (const colName of rightJunctionColumnNames) {
-                              spec[colName] = (
-                                $junction as PgSelectSingleStep<
-                                  any,
-                                  any,
-                                  any,
-                                  any
-                                >
-                              ).get(colName);
-                            }
-
-                            return object(spec);
-                          }
-                        );
-                        const $rights = rightTable.find();
-
-                        // Join the rights to our junction entries; we do
-                        // this because we need to be able to access the
-                        // junction identifier in
-                        // PgManyToManyRelationEdgeTablePlugin (otherwise we
-                        // could have just done a `where` subquery).
-                        const junctionAlias = sql.identifier(junctionSymbol);
-                        if (allowsMultipleEdgesToNode) {
-                          $rights.join({
-                            type: "inner",
-                            source: sql`(${sql.indent`\
-select distinct ${sql.join(
-                              leftJunctionColumnNames.map(
-                                (colName, i) =>
-                                  sql`(el.el->>${sql.literal(colName)})::${
-                                    leftJunctionColumnCodecs[i].sqlType
-                                  } as ${sql.identifier(colName)}`
-                              ),
-                              ", "
-                            )}, ${sql.join(
-                              rightJunctionColumnNames.map(
-                                (colName, i) =>
-                                  sql`(el.el->>${sql.literal(colName)})::${
-                                    rightJunctionColumnCodecs[i].sqlType
-                                  } as ${sql.identifier(colName)}`
-                              ),
-                              ", "
-                            )} from json_array_elements(${$rights.placeholder(
-                              $rightIdentifiers,
-                              TYPES.json
-                            )}) as el(el)`})`,
-                            alias: junctionAlias,
-                            conditions: [
-                              ...rightJunctionColumnNames.map(
-                                (junctionColName, i) => {
-                                  const rightColName =
-                                    rightTableRelationColumnNames[i];
-                                  const sqlRight = sql`${
-                                    $rights.alias
-                                  }.${sql.identifier(
-                                    // TODO: is this safe? What if this column has `via` or `expression`?
-                                    rightColName
-                                  )}`;
-                                  return sql`${junctionAlias}.${sql.identifier(
-                                    junctionColName
-                                  )} = ${sqlRight}`;
-                                }
-                              ),
-                            ],
-                          });
-                        } else {
-                          const junctionTableSource = junctionTable.source;
-                          if (typeof junctionTableSource === "function") {
-                            throw new Error(`Function source forbidden`);
-                          }
-                          $rights.join({
-                            type: "inner",
-                            source: junctionTableSource,
-                            alias: junctionAlias,
-                            conditions: [
-                              sql`(${sql.join(
-                                leftJunctionColumnNames.map(
-                                  (junctionColName, i) => {
-                                    return sql`${junctionAlias}.${sql.identifier(
-                                      // TODO: is this safe? What if this column has `via` or `expression`?
-                                      junctionColName
-                                    )}`;
-                                  }
+                  memo = build.recoverable(memo, () =>
+                    extend(
+                      memo,
+                      {
+                        [manyRelationFieldName]: fieldWithHooks(
+                          {
+                            fieldName: manyRelationFieldName,
+                            pgSource: rightTable,
+                            isPgFieldConnection: isConnection,
+                            isPgFieldSimpleCollection: !isConnection,
+                            isPgManyToManyRelationField: true,
+                            pgManyToManyRightTable: rightTable,
+                          },
+                          () => ({
+                            description: `Reads and enables pagination through a set of \`${
+                              RightTableType!.name
+                            }\`.`,
+                            type: isConnection
+                              ? new GraphQLNonNull(RightTableConnectionType!)
+                              : new GraphQLNonNull(
+                                  new GraphQLList(
+                                    new GraphQLNonNull(RightTableType!)
+                                  )
                                 ),
-                                ", "
-                              )}) in (
+                            args: {},
+                            plan(
+                              $left: PgSelectSingleStep<any, any, any, any>
+                            ) {
+                              const $junctions =
+                                $left.manyRelation(leftRelationName);
+                              // Fetch the identifiers and the return the relevant
+                              // rightTable entries for them.
+                              const $rightIdentifiers = each(
+                                $junctions,
+                                ($junction) => {
+                                  const spec = Object.create(null);
+
+                                  for (const colName of leftJunctionColumnNames) {
+                                    spec[colName] = (
+                                      $junction as PgSelectSingleStep<
+                                        any,
+                                        any,
+                                        any,
+                                        any
+                                      >
+                                    ).get(colName);
+                                  }
+                                  for (const colName of rightJunctionColumnNames) {
+                                    spec[colName] = (
+                                      $junction as PgSelectSingleStep<
+                                        any,
+                                        any,
+                                        any,
+                                        any
+                                      >
+                                    ).get(colName);
+                                  }
+
+                                  return object(spec);
+                                }
+                              );
+                              const $rights = rightTable.find();
+
+                              // Join the rights to our junction entries; we do
+                              // this because we need to be able to access the
+                              // junction identifier in
+                              // PgManyToManyRelationEdgeTablePlugin (otherwise we
+                              // could have just done a `where` subquery).
+                              const junctionAlias =
+                                sql.identifier(junctionSymbol);
+                              if (allowsMultipleEdgesToNode) {
+                                $rights.join({
+                                  type: "inner",
+                                  source: sql`(${sql.indent`\
+select distinct ${sql.join(
+                                    leftJunctionColumnNames.map(
+                                      (colName, i) =>
+                                        sql`(el.el->>${sql.literal(
+                                          colName
+                                        )})::${
+                                          leftJunctionColumnCodecs[i].sqlType
+                                        } as ${sql.identifier(colName)}`
+                                    ),
+                                    ", "
+                                  )}, ${sql.join(
+                                    rightJunctionColumnNames.map(
+                                      (colName, i) =>
+                                        sql`(el.el->>${sql.literal(
+                                          colName
+                                        )})::${
+                                          rightJunctionColumnCodecs[i].sqlType
+                                        } as ${sql.identifier(colName)}`
+                                    ),
+                                    ", "
+                                  )} from json_array_elements(${$rights.placeholder(
+                                    $rightIdentifiers,
+                                    TYPES.json
+                                  )}) as el(el)`})`,
+                                  alias: junctionAlias,
+                                  conditions: [
+                                    ...rightJunctionColumnNames.map(
+                                      (junctionColName, i) => {
+                                        const rightColName =
+                                          rightTableRelationColumnNames[i];
+                                        const sqlRight = sql`${
+                                          $rights.alias
+                                        }.${sql.identifier(
+                                          // TODO: is this safe? What if this column has `via` or `expression`?
+                                          rightColName
+                                        )}`;
+                                        return sql`${junctionAlias}.${sql.identifier(
+                                          junctionColName
+                                        )} = ${sqlRight}`;
+                                      }
+                                    ),
+                                  ],
+                                });
+                              } else {
+                                const junctionTableSource =
+                                  junctionTable.source;
+                                if (typeof junctionTableSource === "function") {
+                                  throw new Error(`Function source forbidden`);
+                                }
+                                $rights.join({
+                                  type: "inner",
+                                  source: junctionTableSource,
+                                  alias: junctionAlias,
+                                  conditions: [
+                                    sql`(${sql.join(
+                                      leftJunctionColumnNames.map(
+                                        (junctionColName, i) => {
+                                          return sql`${junctionAlias}.${sql.identifier(
+                                            // TODO: is this safe? What if this column has `via` or `expression`?
+                                            junctionColName
+                                          )}`;
+                                        }
+                                      ),
+                                      ", "
+                                    )}) in (
                               select distinct ${sql.join(
                                 leftJunctionColumnNames.map(
                                   (colName, i) =>
@@ -251,69 +266,74 @@ select distinct ${sql.join(
                                 ),
                                 ", "
                               )} from json_array_elements(${$rights.placeholder(
-                                $rightIdentifiers,
-                                TYPES.json
-                              )}) as el(el))`,
+                                      $rightIdentifiers,
+                                      TYPES.json
+                                    )}) as el(el))`,
 
-                              ...rightJunctionColumnNames.map(
-                                (junctionColName, i) => {
-                                  const rightColName =
-                                    rightTableRelationColumnNames[i];
-                                  const sqlRight = sql`${
-                                    $rights.alias
-                                  }.${sql.identifier(
-                                    // TODO: is this safe? What if this column has `via` or `expression`?
-                                    rightColName
-                                  )}`;
-                                  return sql`${junctionAlias}.${sql.identifier(
-                                    junctionColName
-                                  )} = ${sqlRight}`;
-                                }
-                              ),
-                            ],
-                          });
-                        }
+                                    ...rightJunctionColumnNames.map(
+                                      (junctionColName, i) => {
+                                        const rightColName =
+                                          rightTableRelationColumnNames[i];
+                                        const sqlRight = sql`${
+                                          $rights.alias
+                                        }.${sql.identifier(
+                                          // TODO: is this safe? What if this column has `via` or `expression`?
+                                          rightColName
+                                        )}`;
+                                        return sql`${junctionAlias}.${sql.identifier(
+                                          junctionColName
+                                        )} = ${sqlRight}`;
+                                      }
+                                    ),
+                                  ],
+                                });
+                              }
 
-                        return isConnection
-                          ? (connection($rights) as any)
-                          : $rights;
+                              return isConnection
+                                ? (connection($rights) as any)
+                                : $rights;
+                            },
+                          })
+                        ),
                       },
-                    })
-                  ),
-                },
 
-                `Many-to-many relation field (${
-                  isConnection ? "connection" : "simple collection"
-                }) on ${
-                  Self.name
-                } type for ${leftRelationName} and ${rightRelationName}.`
-              );
-            }
+                      `Many-to-many relation field (${
+                        isConnection ? "connection" : "simple collection"
+                      }) on ${
+                        Self.name
+                      } type for ${leftRelationName} and ${rightRelationName}.`
+                    )
+                  );
+                }
 
-            const behavior = build.pgGetBehavior([
-              junctionTable.extensions,
-              junctionTable.getRelation(rightRelationName).extensions,
-              rightTable.extensions,
-            ]);
+                const behavior = build.pgGetBehavior([
+                  junctionTable.extensions,
+                  junctionTable.getRelation(rightRelationName).extensions,
+                  rightTable.extensions,
+                ]);
 
-            if (build.behavior.matches(behavior, "manyToMany", "manyToMany")) {
-              if (
-                build.behavior.matches(
-                  behavior,
-                  "connection",
-                  "connection -list"
-                )
-              ) {
-                makeFields(true);
-              }
-              if (
-                build.behavior.matches(behavior, "list", "connection -list")
-              ) {
-                makeFields(false);
-              }
-            }
-            return memo;
-          }, {}),
+                if (
+                  build.behavior.matches(behavior, "manyToMany", "manyToMany")
+                ) {
+                  if (
+                    build.behavior.matches(
+                      behavior,
+                      "connection",
+                      "connection -list"
+                    )
+                  ) {
+                    makeFields(true);
+                  }
+                  if (
+                    build.behavior.matches(behavior, "list", "connection -list")
+                  ) {
+                    makeFields(false);
+                  }
+                }
+                return memo;
+              }),
+            Object.create(null)
+          ),
           `Adding many-to-many relations for ${Self.name}`
         );
       },

--- a/src/createManyToManyConnectionType.ts
+++ b/src/createManyToManyConnectionType.ts
@@ -1,7 +1,11 @@
 import { PgSelectSingleStep } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ExecutableStep } from "grafast";
 import { GraphQLObjectType, GraphQLOutputType } from "graphql";
-import { PgTableSource, PgManyToManyRelationDetails } from "./interfaces.js";
+import {
+  PgTableSource,
+  PgManyToManyRelationDetails,
+  PgManyToManyRelationDetailsWithExtras,
+} from "./interfaces.js";
 
 export default function createManyToManyConnectionType(
   relationship: PgManyToManyRelationDetails,
@@ -27,7 +31,7 @@ export default function createManyToManyConnectionType(
   const junctionTypeName = inflection.tableType(junctionTable.codec);
   const rightTableTypeName = inflection.tableType(rightTable.codec);
 
-  const inflectorInfo = {
+  const inflectorInfo: PgManyToManyRelationDetailsWithExtras = {
     ...relationship,
     leftTableTypeName,
   };


### PR DESCRIPTION
**IGNORE WHITESPACE CHANGES WHEN REVIEWING** otherwise you're going to have a Bad Time.

This hooks into the "recoverable" system which means that SwallowErrorsPlugin can log out the error but continue. Not recommended for production, but it's helpful for trying out plugins to see if they're a good fit. Long term we should improve the conflict messages to hint to the user how to address the issue - most likely with a smart tag or similar.

cc @mattbretl (FYI)