### PR TITLE
bug: Fix simple collection subqueries with multiple reference columns

### DIFF
--- a/__tests__/__snapshots__/queries.test.js.snap
+++ b/__tests__/__snapshots__/queries.test.js.snap
@@ -792,6 +792,107 @@ exports[`schema=f query=f.graphql 1`] = `
 }
 `;
 
+exports[`schema=h query=many-to-many.graphql 1`] = `
+{
+  "data": {
+    "a": {
+      "nodes": [
+        {
+          "members": {
+            "nodes": [
+              {
+                "personName": "Person1",
+              },
+              {
+                "personName": "Person2",
+              },
+            ],
+          },
+          "membersList": [
+            {
+              "personName": "Person1",
+            },
+            {
+              "personName": "Person2",
+            },
+          ],
+          "teamName": "Team1",
+        },
+        {
+          "members": {
+            "nodes": [
+              {
+                "personName": "Person1",
+              },
+            ],
+          },
+          "membersList": [
+            {
+              "personName": "Person1",
+            },
+          ],
+          "teamName": "Team2",
+        },
+        {
+          "members": {
+            "nodes": [],
+          },
+          "membersList": [],
+          "teamName": "Team3",
+        },
+      ],
+    },
+    "b": {
+      "nodes": [
+        {
+          "personName": "Person1",
+          "teams": {
+            "nodes": [
+              {
+                "teamName": "Team1",
+              },
+              {
+                "teamName": "Team2",
+              },
+            ],
+          },
+          "teamsList": [
+            {
+              "teamName": "Team1",
+            },
+            {
+              "teamName": "Team2",
+            },
+          ],
+        },
+        {
+          "personName": "Person2",
+          "teams": {
+            "nodes": [
+              {
+                "teamName": "Team1",
+              },
+            ],
+          },
+          "teamsList": [
+            {
+              "teamName": "Team1",
+            },
+          ],
+        },
+        {
+          "personName": "Person3",
+          "teams": {
+            "nodes": [],
+          },
+          "teamsList": [],
+        },
+      ],
+    },
+  },
+}
+`;
+
 exports[`schema=p query=edge-fields.graphql 1`] = `
 {
   "data": {

--- a/__tests__/helpers.js
+++ b/__tests__/helpers.js
@@ -124,16 +124,15 @@ const getSchemaPath = (sqlSchema) =>
   path.resolve(__dirname, "schemas", sqlSchema);
 
 const getSchemaConfig = async (sqlSchema) => {
-  let config = {};
   const configPath = path.join(getSchemaPath(sqlSchema), "config.json");
   if (fs.existsSync(configPath)) {
     const configJson = await readFile(
       path.join(getSchemaPath(sqlSchema), "config.json"),
       "utf8"
     );
-    config = JSON.parse(configJson);
+    return JSON.parse(configJson);
   }
-  return config;
+  return {};
 };
 
 exports.withRootDb = withRootDb;

--- a/__tests__/helpers.js
+++ b/__tests__/helpers.js
@@ -120,6 +120,24 @@ withPrepopulatedDb.teardown = () => {
   prepopulatedDBKeepalive = null;
 };
 
+const getSchemaPath = (sqlSchema) =>
+  path.resolve(__dirname, "schemas", sqlSchema);
+
+const getSchemaConfig = async (sqlSchema) => {
+  let config = {};
+  const configPath = path.join(getSchemaPath(sqlSchema), "config.json");
+  if (fs.existsSync(configPath)) {
+    const configJson = await readFile(
+      path.join(getSchemaPath(sqlSchema), "config.json"),
+      "utf8"
+    );
+    config = JSON.parse(configJson);
+  }
+  return config;
+};
+
 exports.withRootDb = withRootDb;
 exports.withPrepopulatedDb = withPrepopulatedDb;
 exports.withPgClient = withPgClient;
+exports.getSchemaPath = getSchemaPath;
+exports.getSchemaConfig = getSchemaConfig;

--- a/__tests__/integration/schema/__snapshots__/h.test.js.snap
+++ b/__tests__/integration/schema/__snapshots__/h.test.js.snap
@@ -16,8 +16,9 @@ type Membership implements Node {
   personIdB: Int!
 
   """Reads a single \`Team\` that is related to this \`Membership\`."""
-  teamByTeamId: Team
-  teamId: Int!
+  teamByTeamId1AndTeamId2: Team
+  teamId1: Int!
+  teamId2: Int!
 }
 
 """
@@ -31,8 +32,11 @@ input MembershipCondition {
   """Checks for equality with the object’s \`personIdB\` field."""
   personIdB: Int
 
-  """Checks for equality with the object’s \`teamId\` field."""
-  teamId: Int
+  """Checks for equality with the object’s \`teamId1\` field."""
+  teamId1: Int
+
+  """Checks for equality with the object’s \`teamId2\` field."""
+  teamId2: Int
 }
 
 """A connection to a list of \`Membership\` values."""
@@ -70,8 +74,10 @@ enum MembershipsOrderBy {
   PERSON_ID_B_DESC
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC
-  TEAM_ID_ASC
-  TEAM_ID_DESC
+  TEAM_ID_1_ASC
+  TEAM_ID_1_DESC
+  TEAM_ID_2_ASC
+  TEAM_ID_2_DESC
 }
 
 """An object with a globally unique \`ID\`."""
@@ -428,7 +434,7 @@ type Query implements Node {
   ): Membership
 
   """Get a single \`Membership\`."""
-  membershipByPersonIdAAndPersonIdBAndTeamId(personIdA: Int!, personIdB: Int!, teamId: Int!): Membership
+  membershipByPersonIdAAndPersonIdBAndTeamId1AndTeamId2(personIdA: Int!, personIdB: Int!, teamId1: Int!, teamId2: Int!): Membership
 
   """Fetches an object given its globally unique \`ID\`."""
   node(
@@ -463,11 +469,12 @@ type Query implements Node {
   ): Team
 
   """Get a single \`Team\`."""
-  teamById(id: Int!): Team
+  teamById1AndId2(id1: Int!, id2: Int!): Team
 }
 
 type Team implements Node {
-  id: Int!
+  id1: Int!
+  id2: Int!
 
   """Reads and enables pagination through a set of \`Person\`."""
   members(
@@ -516,7 +523,7 @@ type Team implements Node {
   ): [Person!]!
 
   """Reads and enables pagination through a set of \`Membership\`."""
-  membershipsByTeamId(
+  membershipsByTeamId1AndTeamId2(
     """Read all values in the set after (below) this cursor."""
     after: Cursor
 
@@ -545,7 +552,7 @@ type Team implements Node {
   ): MembershipsConnection!
 
   """Reads and enables pagination through a set of \`Membership\`."""
-  membershipsByTeamIdList(
+  membershipsByTeamId1AndTeamId2List(
     """
     A condition to be used in determining which values should be returned by the collection.
     """
@@ -572,8 +579,11 @@ type Team implements Node {
 A condition to be used against \`Team\` object types. All fields are tested for equality and combined with a logical ‘and.’
 """
 input TeamCondition {
-  """Checks for equality with the object’s \`id\` field."""
-  id: Int
+  """Checks for equality with the object’s \`id1\` field."""
+  id1: Int
+
+  """Checks for equality with the object’s \`id2\` field."""
+  id2: Int
 
   """Checks for equality with the object’s \`teamName\` field."""
   teamName: String
@@ -635,8 +645,10 @@ type TeamsEdge {
 
 """Methods to use when ordering \`Team\`."""
 enum TeamsOrderBy {
-  ID_ASC
-  ID_DESC
+  ID_1_ASC
+  ID_1_DESC
+  ID_2_ASC
+  ID_2_DESC
   NATURAL
   PRIMARY_KEY_ASC
   PRIMARY_KEY_DESC

--- a/__tests__/integration/schema/__snapshots__/h.test.js.snap
+++ b/__tests__/integration/schema/__snapshots__/h.test.js.snap
@@ -1,0 +1,646 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`prints a schema using the 'h' database schema 1`] = `
+"""A location in a connection that can be used for resuming pagination."""
+scalar Cursor
+
+type Membership implements Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+
+  """Reads a single \`Person\` that is related to this \`Membership\`."""
+  personByPersonIdAAndPersonIdB: Person
+  personIdA: Int!
+  personIdB: Int!
+
+  """Reads a single \`Team\` that is related to this \`Membership\`."""
+  teamByTeamId: Team
+  teamId: Int!
+}
+
+"""
+A condition to be used against \`Membership\` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+"""
+input MembershipCondition {
+  """Checks for equality with the object’s \`personIdA\` field."""
+  personIdA: Int
+
+  """Checks for equality with the object’s \`personIdB\` field."""
+  personIdB: Int
+
+  """Checks for equality with the object’s \`teamId\` field."""
+  teamId: Int
+}
+
+"""A connection to a list of \`Membership\` values."""
+type MembershipsConnection {
+  """
+  A list of edges which contains the \`Membership\` and cursor to aid in pagination.
+  """
+  edges: [MembershipsEdge]!
+
+  """A list of \`Membership\` objects."""
+  nodes: [Membership]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`Membership\` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A \`Membership\` edge in the connection."""
+type MembershipsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`Membership\` at the end of the edge."""
+  node: Membership
+}
+
+"""Methods to use when ordering \`Membership\`."""
+enum MembershipsOrderBy {
+  NATURAL
+  PERSON_ID_A_ASC
+  PERSON_ID_A_DESC
+  PERSON_ID_B_ASC
+  PERSON_ID_B_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  TEAM_ID_ASC
+  TEAM_ID_DESC
+}
+
+"""An object with a globally unique \`ID\`."""
+interface Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+}
+
+"""Information about pagination in a connection."""
+type PageInfo {
+  """When paginating forwards, the cursor to continue."""
+  endCursor: Cursor
+
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: Cursor
+}
+
+"""A connection to a list of \`Person\` values."""
+type PeopleConnection {
+  """
+  A list of edges which contains the \`Person\` and cursor to aid in pagination.
+  """
+  edges: [PeopleEdge]!
+
+  """A list of \`Person\` objects."""
+  nodes: [Person]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`Person\` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A \`Person\` edge in the connection."""
+type PeopleEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`Person\` at the end of the edge."""
+  node: Person
+}
+
+"""Methods to use when ordering \`Person\`."""
+enum PeopleOrderBy {
+  ID_A_ASC
+  ID_A_DESC
+  ID_B_ASC
+  ID_B_DESC
+  NATURAL
+  PERSON_NAME_ASC
+  PERSON_NAME_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+type Person implements Node {
+  idA: Int!
+  idB: Int!
+
+  """Reads and enables pagination through a set of \`Membership\`."""
+  membershipsByPersonIdAAndPersonIdB(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: MembershipCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Membership\`."""
+    orderBy: [MembershipsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): MembershipsConnection!
+
+  """Reads and enables pagination through a set of \`Membership\`."""
+  membershipsByPersonIdAAndPersonIdBList(
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: MembershipCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+
+    """The method to use when ordering \`Membership\`."""
+    orderBy: [MembershipsOrderBy!]
+  ): [Membership!]!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  personName: String!
+
+  """Reads and enables pagination through a set of \`Team\`."""
+  teams(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: TeamCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Team\`."""
+    orderBy: [TeamsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PersonTeamsManyToManyConnection!
+
+  """Reads and enables pagination through a set of \`Team\`."""
+  teamsList(
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: TeamCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+
+    """The method to use when ordering \`Team\`."""
+    orderBy: [TeamsOrderBy!]
+  ): [Team!]!
+}
+
+"""
+A condition to be used against \`Person\` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input PersonCondition {
+  """Checks for equality with the object’s \`idA\` field."""
+  idA: Int
+
+  """Checks for equality with the object’s \`idB\` field."""
+  idB: Int
+
+  """Checks for equality with the object’s \`personName\` field."""
+  personName: String
+}
+
+"""A connection to a list of \`Team\` values, with data from \`Membership\`."""
+type PersonTeamsManyToManyConnection {
+  """
+  A list of edges which contains the \`Team\`, info from the \`Membership\`, and the cursor to aid in pagination.
+  """
+  edges: [PersonTeamsManyToManyEdge!]!
+
+  """A list of \`Team\` objects."""
+  nodes: [Team]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`Team\` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A \`Team\` edge in the connection, with data from \`Membership\`."""
+type PersonTeamsManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`Team\` at the end of the edge."""
+  node: Team
+}
+
+"""The root query type which gives access points into the data universe."""
+type Query implements Node {
+  """Reads and enables pagination through a set of \`Membership\`."""
+  allMemberships(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: MembershipCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Membership\`."""
+    orderBy: [MembershipsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): MembershipsConnection
+
+  """Reads a set of \`Membership\`."""
+  allMembershipsList(
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: MembershipCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+
+    """The method to use when ordering \`Membership\`."""
+    orderBy: [MembershipsOrderBy!]
+  ): [Membership!]
+
+  """Reads and enables pagination through a set of \`Person\`."""
+  allPeople(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Person\`."""
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PeopleConnection
+
+  """Reads a set of \`Person\`."""
+  allPeopleList(
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+
+    """The method to use when ordering \`Person\`."""
+    orderBy: [PeopleOrderBy!]
+  ): [Person!]
+
+  """Reads and enables pagination through a set of \`Team\`."""
+  allTeams(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: TeamCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Team\`."""
+    orderBy: [TeamsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): TeamsConnection
+
+  """Reads a set of \`Team\`."""
+  allTeamsList(
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: TeamCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+
+    """The method to use when ordering \`Team\`."""
+    orderBy: [TeamsOrderBy!]
+  ): [Team!]
+
+  """Reads a single \`Membership\` using its globally unique \`ID\`."""
+  membership(
+    """
+    The globally unique \`ID\` to be used in selecting a single \`Membership\`.
+    """
+    nodeId: ID!
+  ): Membership
+
+  """Get a single \`Membership\`."""
+  membershipByPersonIdAAndPersonIdBAndTeamId(personIdA: Int!, personIdB: Int!, teamId: Int!): Membership
+
+  """Fetches an object given its globally unique \`ID\`."""
+  node(
+    """The globally unique \`ID\`."""
+    nodeId: ID!
+  ): Node
+
+  """
+  The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
+  """
+  nodeId: ID!
+
+  """Reads a single \`Person\` using its globally unique \`ID\`."""
+  person(
+    """The globally unique \`ID\` to be used in selecting a single \`Person\`."""
+    nodeId: ID!
+  ): Person
+
+  """Get a single \`Person\`."""
+  personByIdAAndIdB(idA: Int!, idB: Int!): Person
+
+  """
+  Exposes the root query type nested one level down. This is helpful for Relay 1
+  which can only query top level fields if they are in a particular form.
+  """
+  query: Query!
+
+  """Reads a single \`Team\` using its globally unique \`ID\`."""
+  team(
+    """The globally unique \`ID\` to be used in selecting a single \`Team\`."""
+    nodeId: ID!
+  ): Team
+
+  """Get a single \`Team\`."""
+  teamById(id: Int!): Team
+}
+
+type Team implements Node {
+  id: Int!
+
+  """Reads and enables pagination through a set of \`Person\`."""
+  members(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Person\`."""
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+  ): TeamMembersManyToManyConnection!
+
+  """Reads and enables pagination through a set of \`Person\`."""
+  membersList(
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+
+    """The method to use when ordering \`Person\`."""
+    orderBy: [PeopleOrderBy!]
+  ): [Person!]!
+
+  """Reads and enables pagination through a set of \`Membership\`."""
+  membershipsByTeamId(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: MembershipCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """The method to use when ordering \`Membership\`."""
+    orderBy: [MembershipsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): MembershipsConnection!
+
+  """Reads and enables pagination through a set of \`Membership\`."""
+  membershipsByTeamIdList(
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: MembershipCondition
+
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+
+    """The method to use when ordering \`Membership\`."""
+    orderBy: [MembershipsOrderBy!]
+  ): [Membership!]!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  teamName: String!
+}
+
+"""
+A condition to be used against \`Team\` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input TeamCondition {
+  """Checks for equality with the object’s \`id\` field."""
+  id: Int
+
+  """Checks for equality with the object’s \`teamName\` field."""
+  teamName: String
+}
+
+"""
+A connection to a list of \`Person\` values, with data from \`Membership\`.
+"""
+type TeamMembersManyToManyConnection {
+  """
+  A list of edges which contains the \`Person\`, info from the \`Membership\`, and the cursor to aid in pagination.
+  """
+  edges: [TeamMembersManyToManyEdge!]!
+
+  """A list of \`Person\` objects."""
+  nodes: [Person]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`Person\` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A \`Person\` edge in the connection, with data from \`Membership\`."""
+type TeamMembersManyToManyEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`Person\` at the end of the edge."""
+  node: Person
+}
+
+"""A connection to a list of \`Team\` values."""
+type TeamsConnection {
+  """
+  A list of edges which contains the \`Team\` and cursor to aid in pagination.
+  """
+  edges: [TeamsEdge]!
+
+  """A list of \`Team\` objects."""
+  nodes: [Team]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`Team\` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A \`Team\` edge in the connection."""
+type TeamsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`Team\` at the end of the edge."""
+  node: Team
+}
+
+"""Methods to use when ordering \`Team\`."""
+enum TeamsOrderBy {
+  ID_ASC
+  ID_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  TEAM_NAME_ASC
+  TEAM_NAME_DESC
+}
+`;

--- a/__tests__/integration/schema/h.test.js
+++ b/__tests__/integration/schema/h.test.js
@@ -1,0 +1,7 @@
+const { getSchemaConfig } = require("../../helpers");
+const core = require("./core");
+
+test("prints a schema using the 'h' database schema", async () => {
+  const config = await getSchemaConfig("h");
+  return core.test(["h"], config)();
+});

--- a/__tests__/queries.test.js
+++ b/__tests__/queries.test.js
@@ -3,7 +3,7 @@ const fs = require("fs");
 const util = require("util");
 const path = require("path");
 const { grafastGraphql: graphql, hookArgs } = require("grafast");
-const { withPgClient } = require("./helpers");
+const { withPgClient, getSchemaPath, getSchemaConfig } = require("./helpers");
 const { printSchema } = require("graphql");
 const debug = require("debug")("graphile-build:schema");
 const { makeSchema } = require("postgraphile");
@@ -15,41 +15,34 @@ const { PgManyToManyPreset } = require("../");
 
 const readFile = util.promisify(fs.readFile);
 
+const getQueriesPath = (sqlSchema) =>
+  path.join(getSchemaPath(sqlSchema), "fixtures", "queries");
+
 const getSqlSchemas = () =>
   fs.readdirSync(path.resolve(__dirname, "schemas")).sort();
 const getFixturesForSqlSchema = (sqlSchema) =>
-  fs.existsSync(
-    path.resolve(__dirname, "schemas", sqlSchema, "fixtures", "queries")
-  )
-    ? fs
-        .readdirSync(
-          path.resolve(__dirname, "schemas", sqlSchema, "fixtures", "queries")
-        )
-        .sort()
+  fs.existsSync(getQueriesPath(sqlSchema))
+    ? fs.readdirSync(getQueriesPath(sqlSchema)).sort()
     : [];
 const readFixtureForSqlSchema = (sqlSchema, fixture) =>
-  readFile(
-    path.resolve(
-      __dirname,
-      "schemas",
-      sqlSchema,
-      "fixtures",
-      "queries",
-      fixture
-    ),
-    "utf8"
-  );
+  readFile(path.join(getQueriesPath(sqlSchema), fixture), "utf8");
 
 const queryResult = async (sqlSchema, fixture) => {
   return await withPgClient(async (pgClient) => {
     const data = await readFile(
-      path.resolve(__dirname, "schemas", sqlSchema, "data.sql"),
+      path.join(getSchemaPath(sqlSchema), "data.sql"),
       "utf8"
     );
     await pgClient.query(data);
 
+    const config = await getSchemaConfig(sqlSchema);
+
     const { schema, resolvedPreset } = await makeSchema({
-      extends: [postgraphilePresetAmber, makeV4Preset({}), PgManyToManyPreset],
+      extends: [
+        postgraphilePresetAmber,
+        makeV4Preset(config),
+        PgManyToManyPreset,
+      ],
       pgServices: /* makePgServices(DATABASE_URL, ["app_public"]) */ [
         {
           name: "main",

--- a/__tests__/schemas/h/config.json
+++ b/__tests__/schemas/h/config.json
@@ -1,0 +1,5 @@
+{
+    "disableDefaultMutations": true,
+    "legacyRelations": "omit",
+    "simpleCollections": "both"
+  }

--- a/__tests__/schemas/h/data.sql
+++ b/__tests__/schemas/h/data.sql
@@ -1,0 +1,21 @@
+insert into h.person (id_a, id_b, person_name) values
+  (1, 1, 'Person1'),
+  (2, 2, 'Person2'),
+  (3, 3, 'Person3');
+
+insert into h.team (id, team_name) values
+  (1, 'Team1'),
+  (2, 'Team2'),
+  (3, 'Team3');
+
+insert into h.membership (person_id_a, person_id_b, team_id) values
+  (1, 1, 1),
+  (1, 1, 2),
+  (2, 2, 1);
+
+-- Person1: [Team1,Team2]
+-- Person2: [Team1]
+-- Person3: []
+-- Team1: [Person1,Person2]
+-- Team2: [Person1]
+-- Team3: []

--- a/__tests__/schemas/h/data.sql
+++ b/__tests__/schemas/h/data.sql
@@ -3,15 +3,15 @@ insert into h.person (id_a, id_b, person_name) values
   (2, 2, 'Person2'),
   (3, 3, 'Person3');
 
-insert into h.team (id, team_name) values
-  (1, 'Team1'),
-  (2, 'Team2'),
-  (3, 'Team3');
+insert into h.team (id_1, id_2, team_name) values
+  (1, 1, 'Team1'),
+  (2, 2, 'Team2'),
+  (3, 3, 'Team3');
 
-insert into h.membership (person_id_a, person_id_b, team_id) values
-  (1, 1, 1),
-  (1, 1, 2),
-  (2, 2, 1);
+insert into h.membership (person_id_a, person_id_b, team_id_1, team_id_2) values
+  (1, 1, 1, 1),
+  (1, 1, 2, 2),
+  (2, 2, 1, 1);
 
 -- Person1: [Team1,Team2]
 -- Person2: [Team1]

--- a/__tests__/schemas/h/fixtures/queries/many-to-many.graphql
+++ b/__tests__/schemas/h/fixtures/queries/many-to-many.graphql
@@ -1,0 +1,28 @@
+query {
+  a: allTeams {
+    nodes {
+      teamName
+      members {
+        nodes {
+          personName
+        }
+      }
+      membersList {
+        personName
+      }
+    }
+  }
+  b: allPeople {
+    nodes {
+      personName
+      teams {
+        nodes {
+          teamName
+        }
+      }
+      teamsList {
+        teamName
+      }
+    }
+  }
+}

--- a/__tests__/schemas/h/fixtures/queries/many-to-many.graphql
+++ b/__tests__/schemas/h/fixtures/queries/many-to-many.graphql
@@ -7,6 +7,7 @@ query {
           personName
         }
       }
+      # Ensure that simple connections with multiple reference columns work
       membersList {
         personName
       }

--- a/__tests__/schemas/h/schema.sql
+++ b/__tests__/schemas/h/schema.sql
@@ -1,0 +1,26 @@
+drop schema if exists h cascade;
+
+create schema h;
+
+create table h.person (
+  id_a int,
+  id_b int,
+  person_name text not null,
+  primary key (id_a, id_b)
+);
+
+create table h.team (
+  id int primary key,
+  team_name text not null
+);
+
+create table h.membership (
+  person_id_a int,
+  person_id_b int,
+  team_id int constraint membership_team_id_fkey references h.team (id),
+  constraint membership_person_id_fkey foreign key (person_id_a, person_id_b) references h.person (id_a, id_b),
+  primary key (person_id_a, person_id_b, team_id)
+);
+
+comment on constraint membership_person_id_fkey on h.membership is E'@manyToManyFieldName members';
+comment on constraint membership_team_id_fkey on h.membership is E'@manyToManyFieldName teams';

--- a/__tests__/schemas/h/schema.sql
+++ b/__tests__/schemas/h/schema.sql
@@ -10,16 +10,20 @@ create table h.person (
 );
 
 create table h.team (
-  id int primary key,
-  team_name text not null
+  id_1 int,
+  id_2 int,
+  team_name text not null,
+  primary key (id_1, id_2)
 );
 
 create table h.membership (
   person_id_a int,
   person_id_b int,
-  team_id int constraint membership_team_id_fkey references h.team (id),
+  team_id_1 int,
+  team_id_2 int,
   constraint membership_person_id_fkey foreign key (person_id_a, person_id_b) references h.person (id_a, id_b),
-  primary key (person_id_a, person_id_b, team_id)
+  constraint membership_team_id_fkey foreign key (team_id_1, team_id_2) references h.team (id_1, id_2),
+  primary key (person_id_a, person_id_b, team_id_1, team_id_2)
 );
 
 comment on constraint membership_person_id_fkey on h.membership is E'@manyToManyFieldName members';

--- a/src/PgManyToManyRelationPlugin.ts
+++ b/src/PgManyToManyRelationPlugin.ts
@@ -337,7 +337,7 @@ where ${sql.join(leftConditions, "\nand ")}
                                       );
                                     }
 
-                                    const rightJunctionAttributes = sql`(${sql.join(
+                                    const rightJunctionAttributes = sql`${sql.join(
                                       rightJunctionAttributeNames.map(
                                         (n) =>
                                           sql`${junctionAlias}.${sql.identifier(
@@ -345,7 +345,7 @@ where ${sql.join(leftConditions, "\nand ")}
                                           )}`
                                       ),
                                       ", "
-                                    )})`;
+                                    )}`;
                                     const rightTableAttribute = sql`(${sql.join(
                                       rightTableAttributeNames.map(
                                         (n) =>


### PR DESCRIPTION
For simple collection queries where no attributes on the junction table are used, 
an `IN` expression is used in a `WHERE` clause to filter the right table
to records that are in the left filtered junction table. In cases where the right table
has more than one reference columns, the subquery puts the columns in parenthesis
which causes them to be treated as a single compound column rather than a tuple.
This results in an error due to a mismatch in the number of columns on either
side of the expression.

In order to get a working test for this, I had to allow the query tests to set the 
`simpleCollections` option on the V4 presets. To do this, I added an optional 
JSON config file in the schema directory.