### PR TITLE
fix: skip unsafe m2m fields on polymorphic interfaces

### DIFF
--- a/__tests__/polymorphic-interface.test.js
+++ b/__tests__/polymorphic-interface.test.js
@@ -1,0 +1,102 @@
+const { printSchema } = require("graphql");
+const { makeSchema } = require("postgraphile");
+const {
+  default: postgraphilePresetAmber,
+} = require("postgraphile/presets/amber");
+const { makeJSONPgSmartTagsPlugin } = require("postgraphile/utils");
+const pgAdaptor = require("@dataplan/pg/adaptors/pg");
+const { PgManyToManyPreset } = require("../");
+const { withPgClient } = require("./helpers");
+
+const schemaSql = `
+drop schema if exists poly cascade;
+create schema poly;
+
+create table poly.account (
+  id integer primary key,
+  name text not null
+);
+
+create table poly.currency (
+  id integer primary key,
+  code text not null unique
+);
+
+create table poly.event_code (
+  code text primary key
+);
+
+insert into poly.event_code (code) values ('created');
+
+create table poly.session (
+  id integer primary key,
+  account_id integer not null references poly.account(id),
+  currency_id integer not null references poly.currency(id),
+  current_event_id integer
+);
+
+create table poly.event (
+  id integer primary key,
+  session_id integer not null references poly.session(id),
+  code text not null references poly.event_code(code),
+  created_at timestamptz not null default now()
+);
+
+alter table poly.session
+  add constraint session_current_event_id_fkey
+  foreign key (current_event_id) references poly.event(id);
+
+create index session_current_event_id_idx on poly.session(current_event_id);
+create index session_account_id_idx on poly.session(account_id);
+create index session_currency_id_idx on poly.session(currency_id);
+
+create table poly.event__created (
+  id integer primary key references poly.event(id) on delete cascade,
+  note text
+);
+`;
+
+const polymorphismTags = makeJSONPgSmartTagsPlugin({
+  version: 1,
+  config: {
+    class: {
+      "poly.event": {
+        tags: {
+          interface: "mode:relational type:code",
+          type: ["created references:event__created"],
+        },
+      },
+    },
+  },
+});
+
+test("many-to-many candidates do not break relational polymorphic interfaces", async () => {
+  await withPgClient(async (pgClient) => {
+    await pgClient.query(schemaSql);
+
+    const { schema } = await makeSchema({
+      extends: [postgraphilePresetAmber, PgManyToManyPreset],
+      plugins: [polymorphismTags],
+      pgServices: [
+        {
+          name: "main",
+          adaptor: pgAdaptor,
+          pgSettingsKey: "pgSettings",
+          pgSettings: {},
+          withPgClientKey: "withPgClient",
+          withPgClient,
+          pgSettingsForIntrospection: {},
+          schemas: ["poly"],
+          adaptorSettings: {
+            poolClient: pgClient,
+          },
+        },
+      ],
+    });
+
+    const sdl = printSchema(schema);
+
+    expect(sdl).toContain("interface Event");
+    expect(sdl).toContain("type EventCreated implements Event");
+  });
+});

--- a/__tests__/polymorphic-interface.test.js
+++ b/__tests__/polymorphic-interface.test.js
@@ -1,4 +1,3 @@
-const { printSchema } = require("graphql");
 const { makeSchema } = require("postgraphile");
 const {
   default: postgraphilePresetAmber,
@@ -94,9 +93,18 @@ test("many-to-many candidates do not break relational polymorphic interfaces", a
       ],
     });
 
-    const sdl = printSchema(schema);
+    const event = schema.getType("Event");
+    const eventCreated = schema.getType("EventCreated");
 
-    expect(sdl).toContain("interface Event");
-    expect(sdl).toContain("type EventCreated implements Event");
+    expect(event).toBeTruthy();
+    expect(eventCreated.getInterfaces().some((i) => i.name === "Event")).toBe(
+      true
+    );
+    expect(Object.keys(event.getFields())).not.toContain(
+      "accountsBySessionCurrentEventIdAndAccountId"
+    );
+    expect(Object.keys(event.getFields())).not.toContain(
+      "currenciesBySessionCurrentEventIdAndCurrencyId"
+    );
   });
 });

--- a/src/PgManyToManyRelationPlugin.ts
+++ b/src/PgManyToManyRelationPlugin.ts
@@ -1,4 +1,8 @@
-import type { PgCodec, PgResource, PgSelectSingleStep } from "@dataplan/pg";
+import type {
+  PgCodec,
+  PgResource,
+  PgSelectSingleStep,
+} from "@dataplan/pg";
 import type {} from "graphile-config";
 import type { GraphQLObjectType } from "graphql";
 import type { SQL } from "pg-sql2";
@@ -334,6 +338,18 @@ function extendFields(
   if (!relationships || relationships.length === 0) {
     return fields;
   }
+
+  const representedResources = (() => {
+    const polymorphism = context.scope.pgPolymorphism;
+    if (!isInterface || polymorphism?.mode !== "relational") {
+      return null;
+    }
+    return Object.values(polymorphism.types).map((spec) => {
+      const relation = leftTable.getRelation(spec.relationName);
+      return relation.remoteResource as PgTableResource;
+    });
+  })();
+
   return extend(
     fields,
     relationships.reduce(
@@ -379,7 +395,56 @@ function extendFields(
           // TODO: throw an error if localAttributes or remoteAttributes involve
           // `via` or `expression` - we only want pure column relations.
 
+          function representedResourcesHaveField(isConnection: boolean) {
+            if (!representedResources) {
+              return true;
+            }
+            const manyRelationFieldName = isConnection
+              ? inflection.manyToManyRelationConnectionField(relationship)
+              : inflection.manyToManyRelationListField(relationship);
+
+            return representedResources.every((resource) => {
+              const childRelationships =
+                build.pgManyToManyRealtionshipsByResource.get(resource);
+              if (!childRelationships) {
+                return false;
+              }
+              return childRelationships.some((childRelationship) => {
+                if (childRelationship.rightTable !== relationship.rightTable) {
+                  return false;
+                }
+                if (
+                  !build.behavior.pgManyToManyMatches(
+                    childRelationship,
+                    "manyToMany"
+                  )
+                ) {
+                  return false;
+                }
+                if (
+                  !build.behavior.pgManyToManyMatches(
+                    childRelationship,
+                    isConnection ? "connection" : "list"
+                  )
+                ) {
+                  return false;
+                }
+
+                const childRelationFieldName = isConnection
+                  ? inflection.manyToManyRelationConnectionField(
+                      childRelationship
+                    )
+                  : inflection.manyToManyRelationListField(childRelationship);
+                return childRelationFieldName === manyRelationFieldName;
+              });
+            });
+          }
+
           function makeFields(isConnection: boolean) {
+            if (!representedResourcesHaveField(isConnection)) {
+              return;
+            }
+
             const manyRelationFieldName = isConnection
               ? inflection.manyToManyRelationConnectionField(relationship)
               : inflection.manyToManyRelationListField(relationship);


### PR DESCRIPTION
## Summary

Fixes #100.

This prevents `PgManyToManyPreset` from adding many-to-many fields to relational polymorphic interfaces unless every represented resource can expose the same field safely.

Previously the plugin could add fields such as:

```text
Event.accountsBySessionCurrentEventIdAndAccountId
Event.currenciesBySessionCurrentEventIdAndCurrencyId
```

but the concrete type `EventCreated implements Event` did not expose those fields, causing GraphQL schema validation to fail.

The fix keeps those unsafe m2m fields off the interface instead of producing an invalid schema.

## Test Plan

Red before the fix: the new regression test failed with:

```text
Interface field Event.accountsBySessionCurrentEventIdAndAccountId expected but EventCreated does not provide it.
Interface field Event.currenciesBySessionCurrentEventIdAndCurrencyId expected but EventCreated does not provide it.
```

After the fix:

```bash
TEST_DATABASE_URL=<local-postgres-test-db> yarn test
```

Result:

```text
Test Suites: 18 passed, 18 total
Tests: 36 passed, 36 total
Snapshots: 34 passed, 34 total
```

Note: `yarn lint` currently does not start in this checkout because `eslint.config.mjs` imports `eslint-plugin-graphile-export`, which is not present in `package.json`/`node_modules`.
